### PR TITLE
syslog-ng: Fix a license file setting.

### DIFF
--- a/recipes-debian/syslog-ng/syslog-ng_debian.bb
+++ b/recipes-debian/syslog-ng/syslog-ng_debian.bb
@@ -12,7 +12,8 @@ require recipes-debian/sources/syslog-ng.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/syslog-ng-syslog-ng-${PV}"
 
 LICENSE = "GPL-2.0-with-OpenSSL-exception & LGPL-2.1-with-OpenSSL-exception"
-LIC_FILES_CHKSUM = "file://COPYING;md5=24c0c5cb2c83d9f2ab725481e4df5240"
+LIC_FILES_CHKSUM = "file://debian/copyright;md5=896b5aaa7720190a36f9383f1874258e"
+NO_GENERIC_LICENSE[LGPL-2.1-with-OpenSSL-exception] = "debian/copyright"
 
 SRC_URI += " \
     file://configure.ac-add-option-enable-thread-tls-to-manage-.patch \


### PR DESCRIPTION
This change fixes following warning.

```
WARNING: syslog-ng-3.19.1-r0 do_populate_lic: syslog-ng: No generic license file exists for: LGPL-2.1-with-OpenSSL-exception in any provider
```

The license file for LGPL-2.1-with-OpenSSL-exception does not exist in
meta/files/common-files in poky. So, I fixed to specify its license file
given by debian.
https://metadata.ftp-master.debian.org/changelogs/main/s/syslog-ng/syslog-ng_3.19.1-5_copyright

For testing, I confirmed that I could build syslog-ng without any warnings.
```
bitbake syslog-ng
```