### PR TITLE
recipes-debian: Update mirror server URL

### DIFF
--- a/recipes-debian/sources/dpkg.inc
+++ b/recipes-debian/sources/dpkg.inc
@@ -5,8 +5,8 @@ REPACK_PV = "1.19.8"
 PV = "1.19.8"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/d/dpkg/dpkg_1.19.8.dsc;name=dpkg_1.19.8.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/d/dpkg/dpkg_1.19.8.tar.xz;name=dpkg_1.19.8.tar.xz \
+    ${DEBIAN_MIRROR}/main/d/dpkg/dpkg_1.19.8.dsc;name=dpkg_1.19.8.dsc \
+    ${DEBIAN_MIRROR}/main/d/dpkg/dpkg_1.19.8.tar.xz;name=dpkg_1.19.8.tar.xz \
 "
 
 SRC_URI[dpkg_1.19.8.dsc.md5sum] = "34d88e113aea4e432c3f8acb0a395969"

--- a/recipes-debian/sources/flac.inc
+++ b/recipes-debian/sources/flac.inc
@@ -5,15 +5,15 @@ REPACK_PV = "1.3.2"
 PV = "1.3.2"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/f/flac/flac_1.3.2-3+deb10u2.dsc;name=flac_1.3.2-3+deb10u2.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/f/flac/flac_1.3.2.orig.tar.xz;name=flac_1.3.2.orig.tar.xz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/f/flac/flac_1.3.2-3+deb10u2.debian.tar.xz;name=flac_1.3.2-3+deb10u2.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/f/flac/flac_1.3.2-3+deb10u2.dsc;name=flac_1.3.2-3+deb10u2.dsc \
+    ${DEBIAN_MIRROR}/main/f/flac/flac_1.3.2.orig.tar.xz;name=flac_1.3.2.orig.tar.xz \
+    ${DEBIAN_MIRROR}/main/f/flac/flac_1.3.2-3+deb10u2.debian.tar.xz;name=flac_1.3.2-3+deb10u2.debian.tar.xz \
 "
 
-SRC_URI[flac_1.3.2-3+deb10u2.dsc.md5sum] = "f0522d4837da5ae21b1c71d7821354cb"
+SRC_URI[flac_1.3.2-3+deb10u2.dsc.md5sum] = "8b226017cf453781bd0bf5f1876dbcdb"
 SRC_URI[flac_1.3.2.orig.tar.xz.md5sum] = "454f1bfa3f93cc708098d7890d0499bd"
-SRC_URI[flac_1.3.2-3+deb10u2.debian.tar.xz.md5sum] = "de9eef7dd3cb347a93b8017986478480"
+SRC_URI[flac_1.3.2-3+deb10u2.debian.tar.xz.md5sum] = "6b2d9c021a1dde55511f56911fa5b7d3"
 
-SRC_URI[flac_1.3.2-3+deb10u2.dsc.sha256sum] = "cb56753241f7129742b3e7b4747fbef41db4ba5f35b5e493235bd67dc549c2f8"
+SRC_URI[flac_1.3.2-3+deb10u2.dsc.sha256sum] = "968d76bdcf76421be3bac9e5b5cc068bad8c3ce3f0def9ab312bc403dade5982"
 SRC_URI[flac_1.3.2.orig.tar.xz.sha256sum] = "91cfc3ed61dc40f47f050a109b08610667d73477af6ef36dcad31c31a4a8d53f"
-SRC_URI[flac_1.3.2-3+deb10u2.debian.tar.xz.sha256sum] = "c701aba8df32363b6c2b78443cf51962085a31a8ec7357c8867c871465932058"
+SRC_URI[flac_1.3.2-3+deb10u2.debian.tar.xz.sha256sum] = "aa5ede43065d70b8ace7059eb46141380ac2cfbabf3d2e00aac0bb59037bae25"

--- a/recipes-debian/sources/gnupg2.inc
+++ b/recipes-debian/sources/gnupg2.inc
@@ -5,10 +5,10 @@ REPACK_PV = "2.2.12"
 PV = "2.2.12"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.dsc;name=gnupg2_2.2.12-1+deb10u2.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2;name=gnupg2_2.2.12.orig.tar.bz2 \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2.asc;name=gnupg2_2.2.12.orig.tar.bz2.asc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.debian.tar.xz;name=gnupg2_2.2.12-1+deb10u2.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.dsc;name=gnupg2_2.2.12-1+deb10u2.dsc \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2;name=gnupg2_2.2.12.orig.tar.bz2 \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2.asc;name=gnupg2_2.2.12.orig.tar.bz2.asc \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.debian.tar.xz;name=gnupg2_2.2.12-1+deb10u2.debian.tar.xz \
 "
 
 SRC_URI[gnupg2_2.2.12-1+deb10u2.dsc.md5sum] = "5585917b8d5905559eb08a83fe5caa49"

--- a/recipes-debian/sources/gzip.inc
+++ b/recipes-debian/sources/gzip.inc
@@ -5,9 +5,9 @@ REPACK_PV = "1.9"
 PV = "1.9"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.dsc;name=gzip_1.9-3+deb10u1.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gzip/gzip_1.9.orig.tar.gz;name=gzip_1.9.orig.tar.gz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.debian.tar.xz;name=gzip_1.9-3+deb10u1.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.dsc;name=gzip_1.9-3+deb10u1.dsc \
+    ${DEBIAN_MIRROR}/main/g/gzip/gzip_1.9.orig.tar.gz;name=gzip_1.9.orig.tar.gz \
+    ${DEBIAN_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.debian.tar.xz;name=gzip_1.9-3+deb10u1.debian.tar.xz \
 "
 
 SRC_URI[gzip_1.9-3+deb10u1.dsc.md5sum] = "789b70393726b2e2b4203a61da61d82b"

--- a/recipes-debian/sources/libxml2.inc
+++ b/recipes-debian/sources/libxml2.inc
@@ -5,9 +5,9 @@ REPACK_PV = "2.9.4+dfsg1"
 PV = "2.9.4"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/libx/libxml2/libxml2_2.9.4+dfsg1-7+deb10u4.dsc;name=libxml2_2.9.4+dfsg1-7+deb10u4.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/libx/libxml2/libxml2_2.9.4+dfsg1.orig.tar.xz;name=libxml2_2.9.4+dfsg1.orig.tar.xz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/libx/libxml2/libxml2_2.9.4+dfsg1-7+deb10u4.debian.tar.xz;name=libxml2_2.9.4+dfsg1-7+deb10u4.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/libx/libxml2/libxml2_2.9.4+dfsg1-7+deb10u4.dsc;name=libxml2_2.9.4+dfsg1-7+deb10u4.dsc \
+    ${DEBIAN_MIRROR}/main/libx/libxml2/libxml2_2.9.4+dfsg1.orig.tar.xz;name=libxml2_2.9.4+dfsg1.orig.tar.xz \
+    ${DEBIAN_MIRROR}/main/libx/libxml2/libxml2_2.9.4+dfsg1-7+deb10u4.debian.tar.xz;name=libxml2_2.9.4+dfsg1-7+deb10u4.debian.tar.xz \
 "
 
 SRC_URI[libxml2_2.9.4+dfsg1-7+deb10u4.dsc.md5sum] = "68375e62008b8e8ddd51b1e69ad2f495"

--- a/recipes-debian/sources/openssl.inc
+++ b/recipes-debian/sources/openssl.inc
@@ -5,10 +5,10 @@ REPACK_PV = "1.1.1n"
 PV = "1.1.1n"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/o/openssl/openssl_1.1.1n-0+deb10u3.dsc;name=openssl_1.1.1n-0+deb10u3.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/o/openssl/openssl_1.1.1n.orig.tar.gz;name=openssl_1.1.1n.orig.tar.gz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/o/openssl/openssl_1.1.1n.orig.tar.gz.asc;name=openssl_1.1.1n.orig.tar.gz.asc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/o/openssl/openssl_1.1.1n-0+deb10u3.debian.tar.xz;name=openssl_1.1.1n-0+deb10u3.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/o/openssl/openssl_1.1.1n-0+deb10u3.dsc;name=openssl_1.1.1n-0+deb10u3.dsc \
+    ${DEBIAN_MIRROR}/main/o/openssl/openssl_1.1.1n.orig.tar.gz;name=openssl_1.1.1n.orig.tar.gz \
+    ${DEBIAN_MIRROR}/main/o/openssl/openssl_1.1.1n.orig.tar.gz.asc;name=openssl_1.1.1n.orig.tar.gz.asc \
+    ${DEBIAN_MIRROR}/main/o/openssl/openssl_1.1.1n-0+deb10u3.debian.tar.xz;name=openssl_1.1.1n-0+deb10u3.debian.tar.xz \
 "
 
 SRC_URI[openssl_1.1.1n-0+deb10u3.dsc.md5sum] = "a982122e43a637646f884fd9f3cfb274"

--- a/recipes-debian/sources/xz-utils.inc
+++ b/recipes-debian/sources/xz-utils.inc
@@ -5,9 +5,9 @@ REPACK_PV = "5.2.4"
 PV = "5.2.4"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.dsc;name=xz-utils_5.2.4-1+deb10u1.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/x/xz-utils/xz-utils_5.2.4.orig.tar.xz;name=xz-utils_5.2.4.orig.tar.xz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.debian.tar.xz;name=xz-utils_5.2.4-1+deb10u1.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.dsc;name=xz-utils_5.2.4-1+deb10u1.dsc \
+    ${DEBIAN_MIRROR}/main/x/xz-utils/xz-utils_5.2.4.orig.tar.xz;name=xz-utils_5.2.4.orig.tar.xz \
+    ${DEBIAN_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.debian.tar.xz;name=xz-utils_5.2.4-1+deb10u1.debian.tar.xz \
 "
 
 SRC_URI[xz-utils_5.2.4-1+deb10u1.dsc.md5sum] = "5419d0cd232cf7f772f0915c56695aeb"


### PR DESCRIPTION
dpkg, flac, gnupg2, gzip, libxml2, openssl, and xz-utils have been deployed to DEBIAN_MIRROR server. So, use DEBIAN_MIRROR instead of DEBIAN_SECURITY_UPDATE_MIRROR.

All updated packages were able to download from DEBIAN_MIRROR.

```
$ bitbake -f dpkg flac gnupg gzip libxml2 openssl xz -c fetch                                                                                                                                       
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2358 entries from dependency cache.                                                                                                                                                           
NOTE: Resolving any missing task queue dependencies
                                                                                                                                                                                                      
Build Configuration:                                                                                                                                                                                  
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:77012a450d91bf35910707008a788788c81c187e"
meta-debian-extended = "warrior:d3abce811f2c9800f6c8d81c5acb2af196dc12f1"
meta-emlinux         = "HEAD:7f470a5f3f6db98a321657514858c6aff51b95ef"
meta-emlinux-private = "HEAD:b290dafea47dfbd8df7ee9b04af38c9b73c87b68"

NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/dpkg/dpkg_debian.bb, do_fetch                                    | ETA:  0:00:00
NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/flac/flac_debian.bb, do_fetch
NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/gnupg/gnupg_debian.bb, do_fetch
NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/gzip/gzip_debian.bb, do_fetch
NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/libxml/libxml2_debian.bb, do_fetch
NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/openssl/openssl_debian.bb, do_fetch
NOTE: Tainting hash to force rebuild of task /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/xz/xz_debian.bb, do_fetch
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/openssl/openssl_debian.bb.do_fetch is tainted from a forced run                                      | ETA:  0:00:00
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/dpkg/dpkg_debian.bb.do_fetch is tainted from a forced run
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/libxml/libxml2_debian.bb.do_fetch is tainted from a forced run
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/flac/flac_debian.bb.do_fetch is tainted from a forced run
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/xz/xz_debian.bb.do_fetch is tainted from a forced run
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/gzip/gzip_debian.bb.do_fetch is tainted from a forced run
WARNING: /home/build/emlinux/latest-dev/build/../repos/meta-debian/recipes-debian/gnupg/gnupg_debian.bb.do_fetch is tainted from a forced run
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 7 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 7 WARNING messages shown.
```
