### PR TITLE
gzip: fix gzip ptest failure

### DIFF
--- a/recipes-debian/gzip/gzip_debian.bb
+++ b/recipes-debian/gzip/gzip_debian.bb
@@ -36,4 +36,6 @@ do_install_ptest() {
 	    -e 's:${HOSTTOOLS_DIR}/::g'                 \
 	    -e 's:${BASE_WORKDIR}/${MULTIMACH_TARGET_SYS}::g' \
 	    ${B}/tests/Makefile > ${D}${PTEST_PATH}/src/tests/Makefile
+	chmod 755 ${D}${PTEST_PATH}/src/tests/zgrep-abuse
+	chmod 755 ${D}${PTEST_PATH}/src/tests/zgrep-binary
 }


### PR DESCRIPTION
This PR is  same as [meta-debian's PR #313](https://github.com/meta-debian/meta-debian/pull/313).
If merging that PR takes long time, we can use this PR instead of waiting for merge.