### PR TITLE
ninja: Add CVE-2021-4336 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/ninja/ninja_debian.bb
+++ b/recipes-debian/ninja/ninja_debian.bb
@@ -27,3 +27,6 @@ do_install() {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+# This is a different Ninja
+CVE_CHECK_WHITELIST += "CVE-2021-4336"


### PR DESCRIPTION
CVE-2021-4336 is `monitor-ninja` issue, not `ninja` in this recipe.   
Therefore, add CVE-2021-4336 to CVE_CHECK_WHITELIST of ninja.

https://nvd.nist.gov/vuln/detail/CVE-2021-4336
https://security-tracker.debian.org/tracker/CVE-2021-4336