### PR TITLE
coreutils: Backport to add alternative target for nice and printenv from poky

### DIFF
--- a/recipes-debian/coreutils/coreutils_debian.bb
+++ b/recipes-debian/coreutils/coreutils_debian.bb
@@ -1,3 +1,7 @@
+# base recipe : meta/recipes-core/coreutils/coreutils_8.30.bb
+# base branch : warrior
+# base commit : fec5323dba7e23a42073995020c7336f3e6a7de1
+
 SUMMARY = "The basic file, shell and text manipulation utilities"
 DESCRIPTION = "The GNU Core Utilities provide the basic file, shell and text \
 manipulation utilities. These are the core utilities which are expected to exist on \
@@ -43,12 +47,12 @@ PACKAGECONFIG[acl] = "--enable-acl,--disable-acl,acl,"
 PACKAGECONFIG[xattr] = "--enable-xattr,--disable-xattr,attr,"
 PACKAGECONFIG[single-binary] = "--enable-single-binary,--disable-single-binary,,"
 
-# [ df mktemp base64 gets a special treatment and is not included in this
+# [ df mktemp nice printenv base64 gets a special treatment and is not included in this
 bindir_progs = "arch basename chcon cksum comm csplit cut dir dircolors dirname du \
                 env expand expr factor fmt fold groups head hostid id install \
-                join link logname md5sum mkfifo nice nl nohup nproc od paste pathchk \
-                pinky pr printenv printf ptx readlink realpath runcon seq sha1sum sha224sum sha256sum \
-                sha384sum sha512sum shred shuf sort split stdbuf sum tac tail tee test timeout\
+                join link logname md5sum mkfifo nl nohup nproc od paste pathchk \
+                pinky pr printf ptx readlink realpath runcon seq sha1sum sha224sum sha256sum \
+                sha384sum sha512sum shred shuf sort split stdbuf sum tac tail tee test timeout \
                 tr truncate tsort tty unexpand uniq unlink uptime users vdir wc who whoami yes"
 
 # hostname gets a special treatment and is not included in this
@@ -78,7 +82,7 @@ do_install_class-native() {
 }
 
 do_install_append() {
-	for i in df mktemp base64; do mv ${D}${bindir}/$i ${D}${bindir}/$i.${BPN}; done
+	for i in df mktemp nice printenv base64; do mv ${D}${bindir}/$i ${D}${bindir}/$i.${BPN}; done
 
 	install -d ${D}${base_bindir}
 	[ "${base_bindir}" != "${bindir}" ] && for i in ${base_bindir_progs}; do mv ${D}${bindir}/$i ${D}${base_bindir}/$i.${BPN}; done
@@ -97,8 +101,8 @@ inherit update-alternatives
 ALTERNATIVE_PRIORITY = "100"
 # Make hostname's priority higher than busybox but lower than net-tools
 ALTERNATIVE_PRIORITY[hostname] = "90"
-ALTERNATIVE_${PN} = "lbracket ${bindir_progs} ${base_bindir_progs} ${sbindir_progs} base64 mktemp df"
-ALTERNATIVE_${PN}-doc = "base64.1 mktemp.1 df.1 groups.1 kill.1 uptime.1 stat.1  hostname.1"
+ALTERNATIVE_${PN} = "lbracket ${bindir_progs} ${base_bindir_progs} ${sbindir_progs} base64 nice printenv mktemp df"
+ALTERNATIVE_${PN}-doc = "base64.1 nice.1 mktemp.1 df.1 groups.1 kill.1 uptime.1 stat.1 hostname.1"
 
 ALTERNATIVE_LINK_NAME[hostname.1] = "${mandir}/man1/hostname.1"
 
@@ -114,6 +118,13 @@ ALTERNATIVE_LINK_NAME[df] = "${base_bindir}/df"
 ALTERNATIVE_TARGET[df] = "${bindir}/df.${BPN}"
 ALTERNATIVE_LINK_NAME[df.1] = "${mandir}/man1/df.1"
 
+ALTERNATIVE_LINK_NAME[nice] = "${base_bindir}/nice"
+ALTERNATIVE_TARGET[nice] = "${bindir}/nice.${BPN}"
+ALTERNATIVE_LINK_NAME[nice.1] = "${mandir}/man1/nice.1"
+
+ALTERNATIVE_LINK_NAME[printenv] = "${base_bindir}/printenv"
+ALTERNATIVE_TARGET[printenv] = "${bindir}/printenv.${BPN}"
+
 ALTERNATIVE_LINK_NAME[lbracket] = "${bindir}/["
 ALTERNATIVE_TARGET[lbracket] = "${bindir}/lbracket.${BPN}"
 
@@ -126,8 +137,8 @@ python __anonymous() {
     for prog in d.getVar('base_bindir_progs').split():
         d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('base_bindir'), prog))
 
-        for prog in d.getVar('sbindir_progs').split():
-            d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('sbindir'), prog))
+    for prog in d.getVar('sbindir_progs').split():
+        d.setVarFlag('ALTERNATIVE_LINK_NAME', prog, '%s/%s' % (d.getVar('sbindir'), prog))
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Purpose of pull request
Avoid coreutils conflicts with nice and printenv from other recipes, like busybox.

Backport from poky.

This backports the following poky's commits:
069829248b14d89937e48026c8e6b9f05dbeb9c9
23a0378f1873c2cffc647d318eafcb47143aa8d7
fec5323dba7e23a42073995020c7336f3e6a7de1

# Test
1. Build package
2. Run image and test the package on the qemuarm64 environment

## How to test the package
1. Prepare Deby build environment
2. Build qemuarm64 image
3. Run qemuarm64 image
4. Check coreutils commands

### Prepare Deby build environment
Git clone Poky and meta-debian.
```
$ git clone -b warrior https://git.yoctoproject.org/poky.git
$ git clone -b warrior https://github.com/meta-debian/meta-debian.git poky/meta-debian
```
And set the environment variables for build.
```
$ export TEMPLATECONF=meta-debian/conf
$ source ./poky/oe-init-build-env
```
### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
MACHINE = "qemuarm64"
DISTRO = "deby"
IMAGE_INSTALL_append = " coreutils"
```

```
$ bitbake core-image-minimal
```
### Run qemuarm64 image
```
$ runqemu qemuarm64 nographic
```
### Check coreutils commands
```
# find / -name '*coreutils'
# ls --version
# nice --version
# printenv --version
```

## Test result
### Build package
Build succeeded.
```
$ bitbake coreutils
NOTE: Bitbake server didn't start within 5 seconds, waiting for 90
WARNING: Host distribution "ubuntu-20.04" has not been validated with this version of the build system; you may possibly experience unexpected failures. It is recommended that you use a tested distribution.
Parsing recipes: 100% |#######################################################################################################################| Time: 0:00:37
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 73 skipped, 0 masked, 0 errors.
Removing 1 recipes from the aarch64 sysroot: 100% |###########################################################################################| Time: 0:03:07
Removing 2 recipes from the qemuarm64 sysroot: 100% |#########################################################################################| Time: 0:10:37
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "backport-coreutils-alternative-target:ebf7b0770bc32d34d12dd44abae70b32eb7d6a9f"

Initialising tasks: 100% |####################################################################################################################| Time: 0:00:17
Sstate summary: Wanted 342 Found 0 Missed 342 Current 70 (0% match, 16% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1922 tasks of which 1125 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

### Package test
Commands included in coreutils are installed.
Checked the version information with a few commands and no problems.
```
# find / -name '*coreutils'
/bin/mkdir.coreutils
/bin/rmdir.coreutils
/bin/date.coreutils
/bin/cp.coreutils
/bin/mknod.coreutils
/bin/kill.coreutils
/bin/true.coreutils
/bin/uname.coreutils
/bin/sleep.coreutils
/bin/stty.coreutils
/bin/dd.coreutils
/bin/sync.coreutils
/bin/chown.coreutils
/bin/stat.coreutils
/bin/mv.coreutils
/bin/cat.coreutils
/bin/ln.coreutils
/bin/chmod.coreutils
/bin/echo.coreutils
/bin/touch.coreutils
/bin/ls.coreutils
/bin/rm.coreutils
/bin/chgrp.coreutils
/bin/hostname.coreutils
/bin/pwd.coreutils
/bin/false.coreutils
/usr/lib/coreutils
/usr/sbin/chroot.coreutils
/usr/bin/cut.coreutils
/usr/bin/groups.coreutils
/usr/bin/paste.coreutils
/usr/bin/split.coreutils
/usr/bin/shred.coreutils
/usr/bin/unlink.coreutils
/usr/bin/csplit.coreutils
/usr/bin/timeout.coreutils
/usr/bin/link.coreutils
/usr/bin/cksum.coreutils
/usr/bin/test.coreutils
/usr/bin/sha384sum.coreutils
/usr/bin/wc.coreutils
/usr/bin/uptime.coreutils
/usr/bin/fold.coreutils
/usr/bin/join.coreutils
/usr/bin/od.coreutils
/usr/bin/install.coreutils
/usr/bin/pathchk.coreutils
/usr/bin/arch.coreutils
/usr/bin/id.coreutils
/usr/bin/md5sum.coreutils
/usr/bin/tac.coreutils
/usr/bin/sha224sum.coreutils
/usr/bin/sha256sum.coreutils
/usr/bin/seq.coreutils
/usr/bin/basename.coreutils
/usr/bin/sort.coreutils
/usr/bin/printf.coreutils
/usr/bin/expr.coreutils
/usr/bin/mkfifo.coreutils
/usr/bin/runcon.coreutils
/usr/bin/stdbuf.coreutils
/usr/bin/tsort.coreutils
/usr/bin/vdir.coreutils
/usr/bin/env.coreutils
/usr/bin/tty.coreutils
/usr/bin/users.coreutils
/usr/bin/uniq.coreutils
/usr/bin/lbracket.coreutils
/usr/bin/truncate.coreutils
/usr/bin/logname.coreutils
/usr/bin/head.coreutils
/usr/bin/tail.coreutils
/usr/bin/whoami.coreutils
/usr/bin/nohup.coreutils
/usr/bin/sha1sum.coreutils
/usr/bin/base64.coreutils
/usr/bin/pinky.coreutils
/usr/bin/chcon.coreutils
/usr/bin/nice.coreutils
/usr/bin/who.coreutils
/usr/bin/printenv.coreutils
/usr/bin/nproc.coreutils
/usr/bin/readlink.coreutils
/usr/bin/sum.coreutils
/usr/bin/dircolors.coreutils
/usr/bin/mktemp.coreutils
/usr/bin/factor.coreutils
/usr/bin/sha512sum.coreutils
/usr/bin/fmt.coreutils
/usr/bin/pr.coreutils
/usr/bin/shuf.coreutils
/usr/bin/ptx.coreutils
/usr/bin/du.coreutils
/usr/bin/dirname.coreutils
/usr/bin/unexpand.coreutils
/usr/bin/nl.coreutils
/usr/bin/tee.coreutils
/usr/bin/df.coreutils
/usr/bin/comm.coreutils
/usr/bin/dir.coreutils
/usr/bin/realpath.coreutils
/usr/bin/yes.coreutils
/usr/bin/expand.coreutils
/usr/bin/hostid.coreutils
/usr/bin/tr.coreutils
# ls --version
ls (GNU coreutils) 8.30
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Richard M. Stallman and David MacKenzie.
# nice --version
nice (GNU coreutils) 8.30
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David MacKenzie.
# printenv --version
printenv (GNU coreutils) 8.30
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David MacKenzie and Richard Mlynarik.
```
