### PR TITLE
elfutils: Fix the recipe because mistake in ptest's RDEPENDS

### DIFF
--- a/recipes-debian/elfutils/elfutils_debian.bb
+++ b/recipes-debian/elfutils/elfutils_debian.bb
@@ -42,7 +42,7 @@ inherit autotools gettext ptest
 
 EXTRA_OECONF = "--program-prefix=eu- --without-lzma"
 EXTRA_OECONF_append_class-native = " --without-bzlib"
-RDEPENDS_${PN}-ptest = "libasm libelf bash make coreutils ${PN}-binutils"
+RDEPENDS_${PN}-ptest += "libasm libelf bash make coreutils ${PN}-binutils"
 
 EXTRA_OECONF_append_class-target += "--disable-tests-rpath"
 


### PR DESCRIPTION
# Purpose of pull request
Fix an issue where elfutils was not included in RDEPENDS_elfutils-ptest.

# Test
Before applying this patch:
```
$ bitbake -e elfutils | grep 'RDEPENDS_elfutils-ptest='
RDEPENDS_elfutils-ptest="libasm libelf bash make coreutils elfutils-binutils glibc-utils"
```
After applying this patch:
```
$ bitbake -e elfutils | grep 'RDEPENDS_elfutils-ptest='
RDEPENDS_elfutils-ptest=" elfutils libasm libelf bash make coreutils elfutils-binutils glibc-utils"
```