### PR TITLE
curl: Add CVE-2013-2617 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/curl/curl_debian.bb
+++ b/recipes-debian/curl/curl_debian.bb
@@ -75,3 +75,7 @@ RRECOMMENDS_lib${BPN} += "ca-certificates"
 FILES_${PN} += "${datadir}/zsh"
 
 BBCLASSEXTEND = "native nativesdk"
+
+# CVE-2013-2617: It's false positive because it was mistakenly detected as
+#                RubyGem's module.
+CVE_CHECK_WHITELIST = "CVE-2013-2617"


### PR DESCRIPTION
Mitigates an unpatched CVE message printed for curl due to a false possible issue.