### PR TITLE
libarchive: Add CVE-2023-30571 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/libarchive/libarchive_debian.bb
+++ b/recipes-debian/libarchive/libarchive_debian.bb
@@ -40,6 +40,9 @@ SRC_URI += " \
            file://bug1066.patch \
 "
 
+# upstream-wontfix: upstream has documented that reported function is not thread-safe
+CVE_CHECK_WHITELIST += " CVE-2023-30571"
+
 inherit autotools update-alternatives pkgconfig
 
 CPPFLAGS += "-I${WORKDIR}/extra-includes"


### PR DESCRIPTION
The cve-check task reports CVE-2023-30571 is not fixed, but upstream has documented that reported function is not thread-safe. So, add it to CVE_CHECK_WHITELIST.

https://nvd.nist.gov/vuln/detail/CVE-2023-30571
https://security-tracker.debian.org/tracker/CVE-2023-30571

From Poky rev: cd329fc98420f69ec17aa8b619ed1e39f050db99