### PR TITLE
Update DEBIAN_SRC_URI to DEBIAN_MIRROR

### DIFF
--- a/recipes-debian/sources/dpkg.inc
+++ b/recipes-debian/sources/dpkg.inc
@@ -5,8 +5,8 @@ REPACK_PV = "1.19.8"
 PV = "1.19.8"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/d/dpkg/dpkg_1.19.8.dsc;name=dpkg_1.19.8.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/d/dpkg/dpkg_1.19.8.tar.xz;name=dpkg_1.19.8.tar.xz \
+    ${DEBIAN_MIRROR}/main/d/dpkg/dpkg_1.19.8.dsc;name=dpkg_1.19.8.dsc \
+    ${DEBIAN_MIRROR}/main/d/dpkg/dpkg_1.19.8.tar.xz;name=dpkg_1.19.8.tar.xz \
 "
 
 SRC_URI[dpkg_1.19.8.dsc.md5sum] = "34d88e113aea4e432c3f8acb0a395969"

--- a/recipes-debian/sources/gnupg2.inc
+++ b/recipes-debian/sources/gnupg2.inc
@@ -5,10 +5,10 @@ REPACK_PV = "2.2.12"
 PV = "2.2.12"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.dsc;name=gnupg2_2.2.12-1+deb10u2.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2;name=gnupg2_2.2.12.orig.tar.bz2 \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2.asc;name=gnupg2_2.2.12.orig.tar.bz2.asc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.debian.tar.xz;name=gnupg2_2.2.12-1+deb10u2.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.dsc;name=gnupg2_2.2.12-1+deb10u2.dsc \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2;name=gnupg2_2.2.12.orig.tar.bz2 \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12.orig.tar.bz2.asc;name=gnupg2_2.2.12.orig.tar.bz2.asc \
+    ${DEBIAN_MIRROR}/main/g/gnupg2/gnupg2_2.2.12-1+deb10u2.debian.tar.xz;name=gnupg2_2.2.12-1+deb10u2.debian.tar.xz \
 "
 
 SRC_URI[gnupg2_2.2.12-1+deb10u2.dsc.md5sum] = "5585917b8d5905559eb08a83fe5caa49"

--- a/recipes-debian/sources/gzip.inc
+++ b/recipes-debian/sources/gzip.inc
@@ -5,9 +5,9 @@ REPACK_PV = "1.9"
 PV = "1.9"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.dsc;name=gzip_1.9-3+deb10u1.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gzip/gzip_1.9.orig.tar.gz;name=gzip_1.9.orig.tar.gz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.debian.tar.xz;name=gzip_1.9-3+deb10u1.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.dsc;name=gzip_1.9-3+deb10u1.dsc \
+    ${DEBIAN_MIRROR}/main/g/gzip/gzip_1.9.orig.tar.gz;name=gzip_1.9.orig.tar.gz \
+    ${DEBIAN_MIRROR}/main/g/gzip/gzip_1.9-3+deb10u1.debian.tar.xz;name=gzip_1.9-3+deb10u1.debian.tar.xz \
 "
 
 SRC_URI[gzip_1.9-3+deb10u1.dsc.md5sum] = "789b70393726b2e2b4203a61da61d82b"

--- a/recipes-debian/sources/xz-utils.inc
+++ b/recipes-debian/sources/xz-utils.inc
@@ -5,9 +5,9 @@ REPACK_PV = "5.2.4"
 PV = "5.2.4"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.dsc;name=xz-utils_5.2.4-1+deb10u1.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/x/xz-utils/xz-utils_5.2.4.orig.tar.xz;name=xz-utils_5.2.4.orig.tar.xz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.debian.tar.xz;name=xz-utils_5.2.4-1+deb10u1.debian.tar.xz \
+    ${DEBIAN_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.dsc;name=xz-utils_5.2.4-1+deb10u1.dsc \
+    ${DEBIAN_MIRROR}/main/x/xz-utils/xz-utils_5.2.4.orig.tar.xz;name=xz-utils_5.2.4.orig.tar.xz \
+    ${DEBIAN_MIRROR}/main/x/xz-utils/xz-utils_5.2.4-1+deb10u1.debian.tar.xz;name=xz-utils_5.2.4-1+deb10u1.debian.tar.xz \
 "
 
 SRC_URI[xz-utils_5.2.4-1+deb10u1.dsc.md5sum] = "5419d0cd232cf7f772f0915c56695aeb"


### PR DESCRIPTION
# Purpose of pull request

Update DEBIAN_SRC_URI to DEBIAN_MIRROR as the same version exists in both
repositories for DEBIAN_MIRROR and DEBIAN_SECURITY_UPDATE_MIRROR.

See: https://github.com/meta-debian/meta-debian/pull/302

The target packages are as follows:
- dpkg
- gnupg
- gzip
- xz

# Test
## How to the build test
1. Set environment variables.
   ```
   $ export TEST_PACKAGES="dpkg gnupg gzip xz"
   $ export TEST_DISTROS="deby"
   $ export TEST_MACHINES="qemuarm64"
   $ export COMPOSE_HTTP_TIMEOUT=7200
   ```

2. Run build test.
   ```
   $ cd docker
   $ make build_test
   ```

## Test result
```
$ export TEST_PACKAGES="dpkg gnupg gzip xz"
$ export TEST_DISTROS="deby"
$ export TEST_MACHINES="qemuarm64"
$ export COMPOSE_HTTP_TIMEOUT=7200
$ cd docker
docker$ make build_test
docker-compose run --rm build_test
WARNING: The PTEST_RUNNER_TIMEOUT variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
WARNING: The TEST_ENABLE_SECURITY_UPDATE variable is not set. Defaulting to a blank string.
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: These recipes will be tested: dpkg gnupg gzip xz
NOTE: Building dpkg ...
NOTE: Build dpkg: PASS
NOTE: Building gnupg ...
NOTE: Build gnupg: PASS
NOTE: Building gzip ...
NOTE: Build gzip: PASS
NOTE: Building xz ...
NOTE: Build xz: PASS
```
