### PR TITLE
python3: fix test_site of ptest fails

### DIFF
--- a/recipes-debian/python/python3/restore_site-packages_in_sitepackages_paths.diff
+++ b/recipes-debian/python/python3/restore_site-packages_in_sitepackages_paths.diff
@@ -15,3 +15,15 @@ index 88c8046..831afa2 100644
              sitepackages.append(os.path.join(prefix, sys.lib,
                                               "python" + sys.version[:3],
                                               "dist-packages"))
+
+--- a/Lib/test/test_site.py
++++ b/Lib/test/test_site.py
+@@ -269,7 +269,7 @@ class HelperFunctionsTests(unittest.Test
+         dirs = site.getsitepackages()
+         if os.sep == '/':
+             # OS X, Linux, FreeBSD, etc
+-            self.assertEqual(len(dirs), 3)
++            self.assertEqual(len(dirs), 4)
+             wanted = os.path.join('xoxo', 'local', 'lib',
+                                   'python%d.%d' % sys.version_info[:2],
+                                   'dist-packages')


### PR DESCRIPTION
# Purpose of pull request
The restore_site-packages_in_sitepackages_paths.diff patch changes the return value of getsitepackages function, causing the test_getsitepackages test in test.test_site.HelperFunctionsTests to fail.

Therefore, add patch to restore_site-packages_in_sitepackages_paths.diff file that fixes the test code.

# Test
1. Build package
2. Run image and test the package on the qemuarm64 environment

## How to test the package
1. Build qemuarm64 image
2. Run qemu image
3. Prepare to run ptest
4. Run test_site of ptest

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
DISTRO = "deby"
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " python3-ptest"
```
```
$ bitbake core-image-minimal
```

### Run qemu image
```
$ runqemu qemuarm64 nographic qemuparams="-smp 4 -m 8192"
```

### Prepare to run ptest
Modify `/usr/lib/python3/ptest/run-ptest` file to run only test_site test in ptest.
```diff
# cp -a /usr/lib/python3/ptest/run-ptest /usr/lib/python3/ptest/run-ptest.orig
# vi /usr/lib/python3/ptest/run-ptest
# diff -up /usr/lib/python3/ptest/run-ptest.orig /usr/lib/python3/ptest/run-ptes
t
--- /usr/lib/python3/ptest/run-ptest.orig
+++ /usr/lib/python3/ptest/run-ptest
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python3 -m test -v | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -e '/\.\.\. [ERROR|FAIL]/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'
+python3 -m test -v test_site | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -e '/\.\.\. [ERROR|FAIL]/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'
```

### Run test_site of ptest
```
# ptest-runner -t 7200 python3
```

## Test result
### Build package
Build succeeded.
```
$ bitbake python3
Parsing recipes: 100% |##############################################################################| Time: 0:00:40
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 73 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-python3-ptest-test-site:71f1e3d080fe82005be9d73471fbba88d1d2c0b6"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |###########################################################################| Time: 0:00:02
Sstate summary: Wanted 411 Found 0 Missed 411 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1924 tasks of which 0 didn't need to be rerun and all succeeded.
```

### Package test
The test_site tests of ptest was all passed.
```
# ptest-runner -t 7200 python3
START: ptest-runner
2023-12-12T05:32
BEGIN: /usr/lib/python3/ptest
== CPython 3.7.3 (default, Dec 12 2023, 04:22:14) [GCC 8.3.0]
== Linux-4.19.299-cip105-aarch64-with-debian-10.13 little-endian
== cwd: /var/volatile/tmp/test_python_2066
== CPU count: 4
== encodings: locale=UTF-8, FS=utf-8
Run tests sequentially
0:00:02 load avg: 3.18 [1/1] test_site
PASS: test__getuserbase (test.test_site.HelperFunctionsTests)
PASS: test_addpackage (test.test_site.HelperFunctionsTests)
PASS: test_addpackage_import_bad_exec (test.test_site.HelperFunctionsTests)
PASS: test_addpackage_import_bad_pth_file (test.test_site.HelperFunctionsTests)
PASS: test_addpackage_import_bad_syntax (test.test_site.HelperFunctionsTests)
PASS: test_addsitedir (test.test_site.HelperFunctionsTests)
PASS: test_get_path (test.test_site.HelperFunctionsTests)
PASS: test_getsitepackages (test.test_site.HelperFunctionsTests)
PASS: test_getuserbase (test.test_site.HelperFunctionsTests)
PASS: test_getusersitepackages (test.test_site.HelperFunctionsTests)
PASS: test_init_pathinfo (test.test_site.HelperFunctionsTests)
PASS: test_makepath (test.test_site.HelperFunctionsTests)
PASS: test_no_home_directory (test.test_site.HelperFunctionsTests)
PASS: test_s_option (test.test_site.HelperFunctionsTests)
PASS: test_abs_paths (test.test_site.ImportSideEffectTests)
SKIP: test_add_build_dir (test.test_site.ImportSideEffectTests) 'test not implemented'
PASS: test_aliasing_mbcs (test.test_site.ImportSideEffectTests)
SKIP: test_license_exists_at_url (test.test_site.ImportSideEffectTests) "resource 'network' is not enabled"
PASS: test_no_duplicate_paths (test.test_site.ImportSideEffectTests)
PASS: test_setting_copyright (test.test_site.ImportSideEffectTests)
PASS: test_setting_help (test.test_site.ImportSideEffectTests)
PASS: test_setting_quit (test.test_site.ImportSideEffectTests)
PASS: test_sitecustomize_executed (test.test_site.ImportSideEffectTests)
PASS: test_startup_imports (test.test_site.StartupImportTests)
PASS: test_startup_interactivehook (test.test_site.StartupImportTests)
PASS: test_startup_interactivehook_isolated (test.test_site.StartupImportTests)
PASS: test_startup_interactivehook_isolated_explicit (test.test_site.StartupImportTests)
SKIP: test_underpth_file (test.test_site._pthFileTests) 'only supported on Windows'
SKIP: test_underpth_nosite_file (test.test_site._pthFileTests) 'only supported on Windows'

----------------------------------------------------------------------

Ran 29 tests in 25.743s

OK (skipped=4)
test_site passed in 34 sec 762 ms

== Tests result: SUCCESS ==

1 test OK.

Total duration: 36 sec 796 ms
Tests result: SUCCESS
DURATION: 99
END: /usr/lib/python3/ptest
2023-12-12T05:34
STOP: ptest-runner
```

For reference, the results before applying this patch:
```
# ptest-runner -t 7200 python3
START: ptest-runner
2023-12-12T06:34
BEGIN: /usr/lib/python3/ptest
== CPython 3.7.3 (default, Dec 12 2023, 05:50:29) [GCC 8.3.0]
== Linux-4.19.299-cip105-aarch64-with-debian-10.13 little-endian
== cwd: /var/volatile/tmp/test_python_2062
== CPU count: 4
== encodings: locale=UTF-8, FS=utf-8
Run tests sequentially
0:00:00 load avg: 1.05 [1/1] test_site
PASS: test__getuserbase (test.test_site.HelperFunctionsTests)
PASS: test_addpackage (test.test_site.HelperFunctionsTests)
PASS: test_addpackage_import_bad_exec (test.test_site.HelperFunctionsTests)
PASS: test_addpackage_import_bad_pth_file (test.test_site.HelperFunctionsTests)
PASS: test_addpackage_import_bad_syntax (test.test_site.HelperFunctionsTests)
PASS: test_addsitedir (test.test_site.HelperFunctionsTests)
PASS: test_get_path (test.test_site.HelperFunctionsTests)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
PASS: test_getuserbase (test.test_site.HelperFunctionsTests)
PASS: test_getusersitepackages (test.test_site.HelperFunctionsTests)
PASS: test_init_pathinfo (test.test_site.HelperFunctionsTests)
PASS: test_makepath (test.test_site.HelperFunctionsTests)
PASS: test_no_home_directory (test.test_site.HelperFunctionsTests)
PASS: test_s_option (test.test_site.HelperFunctionsTests)
PASS: test_abs_paths (test.test_site.ImportSideEffectTests)
SKIP: test_add_build_dir (test.test_site.ImportSideEffectTests) 'test not implemented'
PASS: test_aliasing_mbcs (test.test_site.ImportSideEffectTests)
SKIP: test_license_exists_at_url (test.test_site.ImportSideEffectTests) "resource 'network' is not enabled"
PASS: test_no_duplicate_paths (test.test_site.ImportSideEffectTests)
PASS: test_setting_copyright (test.test_site.ImportSideEffectTests)
PASS: test_setting_help (test.test_site.ImportSideEffectTests)
PASS: test_setting_quit (test.test_site.ImportSideEffectTests)
PASS: test_sitecustomize_executed (test.test_site.ImportSideEffectTests)
PASS: test_startup_imports (test.test_site.StartupImportTests)
PASS: test_startup_interactivehook (test.test_site.StartupImportTests)
PASS: test_startup_interactivehook_isolated (test.test_site.StartupImportTests)
PASS: test_startup_interactivehook_isolated_explicit (test.test_site.StartupImportTests)
SKIP: test_underpth_file (test.test_site._pthFileTests) 'only supported on Windows'
test test_site failed
SKIP: test_underpth_nosite_file (test.test_site._pthFileTests) 'only supported on Windows'

======================================================================
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/test/test_site.py", line 272, in test_getsitepackages
    self.assertEqual(len(dirs), 3)
AssertionError: 4 != 3

----------------------------------------------------------------------

Ran 29 tests in 4.690s

FAILED (failures=1, skipped=4)
test_site failed

== Tests result: FAILURE ==

1 test failed:
    test_site

Total duration: 6 sec 360 ms
Tests result: FAILURE
DURATION: 16
END: /usr/lib/python3/ptest
2023-12-12T06:34
STOP: ptest-runner
```