### PR TITLE
Fix to python ptest output with sed

### DIFF
--- a/recipes-debian/python/python/run-ptest
+++ b/recipes-debian/python/python/run-ptest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python -mtest -W | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -e '/\.\.\. [ERROR|FAIL]/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'

--- a/recipes-debian/python/python/run-ptest
+++ b/recipes-debian/python/python/run-ptest
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python -mtest -W | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -e '/\.\.\. [ERROR|FAIL]/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'
+python -mtest -W | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -r -e '/\.\.\. (ERROR|FAIL)/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'

--- a/recipes-debian/python/python3/run-ptest
+++ b/recipes-debian/python/python3/run-ptest
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python3 -m test -v | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -e '/\.\.\. [ERROR|FAIL]/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'
+python3 -m test -v | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -r -e '/\.\.\. (ERROR|FAIL)/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'

--- a/recipes-debian/python/python3/run-ptest
+++ b/recipes-debian/python/python3/run-ptest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python3 -m test -v | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -e '/\.\.\. [ERROR|FAIL]/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'


### PR DESCRIPTION
# Purpose of pull request
Fix an issue it test results were output incorrectly, 
because incorrect sed command parameter in run-ptest file, 
for python2 and python3.

- Copied run-ptest files from Poky's python2 and python3 respectively.
- Fix run-ptest file for python2 and python3, using Poky-dunfell as reference.

# Test
1. Build package
2. Run image and test the package on the qemuarm64 environment

## How to test the package
1. Build qemuarm64 image
2. Run qemu image
3. Prepare to run ptest
4. Run ptest and check result

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
DISTRO = "deby"
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " python-ptest"
IMAGE_INSTALL_append = " python3-ptest"
```
```
$ bitbake core-image-minimal
```

### Run qemu image
```
$ runqemu qemuarm64 nographic qemuparams="-smp 4 -m 8192"
```

### Prepare to run ptest
Create `/etc/hosts` file.
```
# echo '127.0.0.1 localhost' >> /etc/hosts
```

### Run ptest and check result
```
# ptest-runner -t 7200 python 2>&1 | tee python2.log
# echo "python: PASS/SKIP/FAIL = `grep '^PASS:' python2.log | wc -l`/`grep '^SKIP:' python2.log | wc -l`/`grep '^FAIL:' python2.log | wc -l`"
# grep '^FAIL:' python2.log
```
```
# ptest-runner -t 7200 python3 2>&1 | tee python3.log
# echo "python3: PASS/SKIP/FAIL = `grep '^PASS:' python3.log | wc -l`/`grep '^SKIP:' python3.log | wc -l`/`grep '^FAIL:' python3.log | wc -l`"
# grep '^FAIL:' python3.log
```

## Test result
### Build package
Build succeeded for python2.
```
$ bitbake python
Parsing recipes: 100% |##############################################################################| Time: 0:00:48
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 73 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-to-python-ptest-output-with-sed:1b992f952089dbdfbb433d0ee7816ac580d9bccd"

Initialising tasks: 100% |###########################################################################| Time: 0:00:01
Sstate summary: Wanted 420 Found 0 Missed 420 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1963 tasks of which 0 didn't need to be rerun and all succeeded.
```

Build succeeded for python3.
```
$ bitbake python3
Parsing recipes: 100% |##############################################################################| Time: 0:00:44
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 73 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-to-python-ptest-output-with-sed:1b992f952089dbdfbb433d0ee7816ac580d9bccd"

Initialising tasks: 100% |###########################################################################| Time: 0:00:01
Sstate summary: Wanted 411 Found 0 Missed 411 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1924 tasks of which 0 didn't need to be rerun and all succeeded.
```

### Package test
Confirmed that count of FAILs has decreased.
- python2: 
  before: `python: PASS/SKIP/FAIL = 408/42/15`
  after: `python: PASS/SKIP/FAIL = 445/42/14`
- python3: 
  before: python3: `PASS/SKIP/FAIL = 30478/1221/8`
  after: python3: `PASS/SKIP/FAIL = 30478/1221/7`

For python2.
```
# echo "python: PASS/SKIP/FAIL = `grep '^PASS:' python2.log | wc -l`/`grep '^SKI
P:' python2.log | wc -l`/`grep '^FAIL:' python2.log | wc -l`"
python: PASS/SKIP/FAIL = 445/42/14
# grep '^FAIL:' python2.log
FAIL: test_build_ext (distutils.tests.test_build_ext.BuildExtTestCase)
FAIL: test_get_outputs (distutils.tests.test_build_ext.BuildExtTestCase)
FAIL: test_get_python_inc (distutils.tests.test_sysconfig.SysconfigTestCase)
FAIL: test_record_extensions (distutils.tests.test_install.InstallTestCase)
FAIL: test_search_cpp (distutils.tests.test_config_cmd.ConfigTestCase)
FAIL: test_get_python_inc (distutils.tests.test_sysconfig.SysconfigTestCase)
FAIL: test_iteration_torture (test.test_file2k.FileThreadingTests)
FAIL: test_import_initless_directory_warning (test.test_import.ImportTests)
FAIL: test_import_initless_directory_warning (test.test_import.ImportTests)
FAIL: testEncodings (test.test_minidom.MinidomTest)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_no_home_directory (test.test_site.HelperFunctionsTests)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_no_home_directory (test.test_site.HelperFunctionsTests)
```

For python3.
```
# echo "python3: PASS/SKIP/FAIL = `grep '^PASS:' python3.log | wc -l`/`grep '^SK
IP:' python3.log | wc -l`/`grep '^FAIL:' python3.log | wc -l`"
python3: PASS/SKIP/FAIL = 30478/1221/7
# grep '^FAIL:' python3.log
FAIL: test_create_server_ipv6 (test.test_asyncio.test_base_events.BaseEventLoopWithSelectorTests)
FAIL: test_create_server_ipv6 (test.test_asyncio.test_base_events.BaseEventLoopWithSelectorTests)
FAIL: test_imap4_host_default_value (test.test_imaplib.TestImaplib)
FAIL: test_imap4_host_default_value (test.test_imaplib.TestImaplib)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_with_pip (test.test_venv.EnsurePipTest)
```

### For reference, the results before applying this patch:
For python2.
```
# echo "python: PASS/SKIP/FAIL = `grep '^PASS:' python2.log | wc -l`/`grep '^SKI
P:' python2.log | wc -l`/`grep '^FAIL:' python2.log | wc -l`"
python: PASS/SKIP/FAIL = 408/42/15
# grep '^FAIL:' python2.log
FAIL: test_record_extensions (distutils.tests.test_install.InstallTestCase)
FAIL: test_get_python_inc (distutils.tests.test_sysconfig.SysconfigTestCase)
FAIL: test_search_cpp (distutils.tests.test_config_cmd.ConfigTestCase)
FAIL: test_build_ext (distutils.tests.test_build_ext.BuildExtTestCase)
FAIL: test_get_outputs (distutils.tests.test_build_ext.BuildExtTestCase)
FAIL: test_get_python_inc (distutils.tests.test_sysconfig.SysconfigTestCase)
FAIL: test_import_initless_directory_warning (test.test_import.ImportTests)
FAIL: test_import_initless_directory_warning (test.test_import.ImportTests)
FAIL: testEncodings (test.test_minidom.MinidomTest)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_no_home_directory (test.test_site.HelperFunctionsTests)
FAIL: test_s_option (test.test_site.HelperFunctionsTests)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_no_home_directory (test.test_site.HelperFunctionsTests)
FAIL: test_s_option (test.test_site.HelperFunctionsTests)
```

For python3.
```
# echo "python3: PASS/SKIP/FAIL = `grep '^PASS:' python3.log | wc -l`/`grep '^SK
IP:' python3.log | wc -l`/`grep '^FAIL:' python3.log | wc -l`"
python3: PASS/SKIP/FAIL = 30478/1221/8
# grep '^FAIL:' python3.log
FAIL: test_create_server_ipv6 (test.test_asyncio.test_base_events.BaseEventLoopWithSelectorTests)
FAIL: test_create_server_ipv6 (test.test_asyncio.test_base_events.BaseEventLoopWithSelectorTests)
FAIL: test_imap4_host_default_value (test.test_imaplib.TestImaplib)
FAIL: test_imap4_host_default_value (test.test_imaplib.TestImaplib)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_getsitepackages (test.test_site.HelperFunctionsTests)
FAIL: test_with_pip (test.test_venv.EnsurePipTest)
FAIL: test_doctest_main_issue4197 (test.test_zipimport_support.ZipSupportTests) ... Expected line File "/var/volatile/tmp/tmpgoy7x1wj/script.py", line 2, in __main__.Test
```
