### PR TITLE
coreutils: Add ptest

### DIFF
--- a/recipes-debian/coreutils/coreutils/run-ptest
+++ b/recipes-debian/coreutils/coreutils/run-ptest
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# remove any stale lock files so that the calls to groupadd/useradd don't stop
+# the ptest if re-using the same image
+rm -rf /etc/passwd.lock /etc/group.lock /etc/gshadow.lock
+
+COREUTILSLIB=@libdir@/coreutils
+LOG="${COREUTILSLIB}/ptest/coreutils_ptest_$(date +%Y%m%d-%H%M%S).log"
+USERNAME="tester"
+groupadd ugroup1
+groupadd ugroup2
+useradd -G ugroup1,ugroup2 $USERNAME || echo "user $USERNAME already exists"
+
+su tester -c "cd ${COREUTILSLIB}/ptest && make check-TESTS top_srcdir=. srcdir=." 2>&1 | tee -a ${LOG}
+userdel $USERNAME
+groupdel ugroup1
+groupdel ugroup2

--- a/recipes-debian/coreutils/coreutils_debian.bb
+++ b/recipes-debian/coreutils/coreutils_debian.bb
@@ -26,6 +26,7 @@ SRC_URI += " \
            file://0001-uname-report-processor-and-hardware-correctly.patch \
            file://disable-ls-output-quoting.patch \
            file://0001-local.mk-fix-cross-compiling-problem.patch \
+           file://run-ptest \
           "
 
 EXTRA_OECONF_class-native = "--without-gmp"
@@ -142,3 +143,44 @@ python __anonymous() {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+inherit ptest
+
+RDEPENDS_${PN}-ptest += "bash findutils gawk liberror-perl make perl perl-modules python3-core sed shadow"
+
+do_install_ptest () {
+    install -d ${D}${PTEST_PATH}/tests
+    cp -r ${S}/tests/* ${D}${PTEST_PATH}/tests
+    sed -i 's/ginstall/install/g'  `grep -R ginstall ${D}${PTEST_PATH}/tests | awk -F: '{print $1}' | uniq`
+    install -d ${D}${PTEST_PATH}/build-aux
+    install ${S}/build-aux/test-driver ${D}${PTEST_PATH}/build-aux/
+    install -Dm 0644 ${B}/lib/config.h ${D}${PTEST_PATH}/lib/config.h
+    cp ${B}/Makefile ${D}${PTEST_PATH}/
+    cp ${S}/init.cfg ${D}${PTEST_PATH}/
+    cp -r ${B}/src ${D}${PTEST_PATH}/
+    cp -r ${S}/src/*.c ${D}${PTEST_PATH}/src
+    sed -i '/^VPATH/s/= .*$/= ./g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^PROGRAMS/s/^/#/g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^Makefile: /s/^.*$/Makefile:/g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^abs_srcdir/s/= .*$/= \$\{PWD\}/g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^abs_top_builddir/s/= .*$/= \$\{PWD\}/g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^abs_top_srcdir/s/= .*$/= \$\{PWD\}/g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^built_programs/s/ginstall/install/g' ${D}${PTEST_PATH}/Makefile
+    sed -i '/^CC =/s/ --sysroot=.*recipe-sysroot/ /g' ${D}${PTEST_PATH}/Makefile
+    chmod -R 777 ${D}${PTEST_PATH}
+
+    # Disable subcase stty-pairs.sh, it will cause test framework hang
+    sed -i '/stty-pairs.sh/d' ${D}${PTEST_PATH}/Makefile
+
+    # Disable subcase tail-2/assert.sh as it has issues on 32-bit systems
+    sed -i '/assert.sh/d' ${D}${PTEST_PATH}/Makefile
+
+    # Tweak test d_type-check to use python3 instead of python
+    sed -i "1s@.*@#!/usr/bin/python3@" ${D}${PTEST_PATH}/tests/d_type-check
+    install ${B}/src/getlimits ${D}/${bindir}
+
+    # handle multilib
+    sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
+}
+
+FILES_${PN}-ptest += "${bindir}/getlimits"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of coreutils package based on the following recipe:

* base recipe: https://git.yoctoproject.org/poky/tree/meta/recipes-core/coreutils/coreutils_9.4.bb?id=3e50e45917831d9da2d86e69fb908a1a78483b62
* base branch: master
* base commit: 3e50e45917831d9da2d86e69fb908a1a78483b62

NOTE: This PR is reviewed and approved by @ML-HirotakaFurukawa at https://github.com/ML-HirotakaFurukawa/meta-debian/pull/8 in advance.

# Test
## How to test

1. Enable ptest and install coreutils package
```
$ . setup-emlinux
$ cat << EOS >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " coreutils"
EOS
```

2. Build core-image-minimal image
```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of coreutils

```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner coreutils
```

## Test result

```
root@qemuarm64:~# ptest-runner -l
Available ptests:
acl     /usr/lib/acl/ptest/run-ptest
busybox /usr/lib/busybox/ptest/run-ptest
coreutils       /usr/lib/coreutils/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
root@qemuarm64:~# ptest-runner coreutils
START: ptest-runner
2023-12-21T01:39
BEGIN: /usr/lib/coreutils/ptest
make[1]: Entering directory '/usr/lib/coreutils/ptest'
[   24.814790] random: mktemp: uninitialized urandom read (4 bytes read)
[   66.399511] random: mktemp: uninitialized urandom read (4 bytes read)
[   73.734943] random: shred: uninitialized urandom read (2048 bytes read)
PASS: tests/misc/help-version.sh
...(snip)...
mkdir -p tests/factor
/bin/bash ./tests/factor/create-test.sh tests/factor/t36.sh \
  ./tests/factor/run.sh > tests/factor/t36.sh-t
chmod a+x tests/factor/t36.sh-t
mv -f tests/factor/t36.sh-t tests/factor/t36.sh
t36.sh: skipped test: very expensive: disabled by default
SKIP: tests/factor/t36.sh
============================================================================
Testsuite summary for GNU coreutils 8.30
============================================================================
# TOTAL: 606
# PASS:  473
# SKIP:  133
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/coreutils/ptest'
DURATION: 2136
END: /usr/lib/coreutils/ptest
2023-12-21T02:15
STOP: ptest-runner
```

[ptest-coreutils.log](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13735332/ptest-coreutils.log)

## Test summary

* TOTAL: 606
  * PASS: 473
  * SKIP: 133
  * FAIL: 0

I executed this ptest 3 times and obtained the same results.