### PR TITLE
ncurses: Add ptest

### DIFF
--- a/recipes-debian/ncurses/ncurses/run-ptest
+++ b/recipes-debian/ncurses/ncurses/run-ptest
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+NCURSESLIB=@libdir@/ncurses
+LOG="$NCURSESLIB/ptest/ncurses_ptest_$(date +%Y%m%d-%H%M%S).log"
+
+find . -type f -perm 755 -name test_setupterm -exec {} -a \; | sed '/^OK /s/^/PASS: /; /^ERR /s/^/FAIL: /' | tee -a "$LOG"
+
+PASSED=$(grep -c '^PASS: ' "$LOG")
+FAILED=$(grep -c '^FAIL: ' "$LOG")
+ALL=$((PASSED + FAILED))
+
+(   echo "=== Test Summary ==="
+    echo "TOTAL: $ALL"
+    echo "PASSED: $PASSED"
+    echo "FAILED: $FAILED"
+) | tee -a "$LOG"

--- a/recipes-debian/ncurses/ncurses_debian.bb
+++ b/recipes-debian/ncurses/ncurses_debian.bb
@@ -11,3 +11,28 @@ require recipes-debian/sources/ncurses.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/${BPN}-${@d.getVar('PV', True).replace('+','-')}"
 
 EXTRA_OECONF += "--with-abi-version=5"
+
+SRC_URI += "file://run-ptest"
+
+inherit ptest
+EXTRA_OECONF += "${@bb.utils.contains('PTEST_ENABLED', '1', '--with-tests', '', d)}"
+
+do_compile_ptest() {
+    oe_runmake -C narrowc/test all
+    ! ${ENABLE_WIDEC} || \
+        oe_runmake -C widec/test all
+}
+
+do_install_ptest() {
+    install -dm 755 ${D}${PTEST_PATH}/narrowc/
+    install -m 755 ${B}/narrowc/test/test_setupterm ${D}${PTEST_PATH}/narrowc/
+    if [ ${ENABLE_WIDEC} ]; then
+        install -dm 755 ${D}${PTEST_PATH}/widec/
+        install -m 755 ${B}/widec/test/test_setupterm ${D}${PTEST_PATH}/widec/
+    fi
+
+    # handle multilib
+    sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
+}
+
+RDEPENDS_${PN}-ptest += "${PN}-terminfo"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of ncurses package.
This ptest is based on the test code of `test/` directory in the source code of ncurses.

NOTE: This PR was reviewed and approved by @ML-HirotakaFurukawa at https://github.com/ML-HirotakaFurukawa/meta-debian/pull/9 in advance.

# Note

There are some test programs under `test/` directory in the source code of ncurses, but most of them are demos, games or tests which requries manual intervention, so inappropriate for ptest.
It seems the only usable test is "test_setupterm", which checks terminfo.
Therefore, this ptest will execute this test only and check the result.

# Test
## How to test

1. Enable ptest and install ncurses package
```
$ . setup-emlinux
$ cat << EOS >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " ncurses"
EOS
```

2. Build core-image-minimal image
```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of ncurses
```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner ncurses
```

## Test result

```
root@qemuarm64:~# ptest-runner -l
Available ptests:
acl     /usr/lib/acl/ptest/run-ptest
busybox /usr/lib/busybox/ptest/run-ptest
ncurses /usr/lib/ncurses/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
root@qemuarm64:~# ptest-runner ncurses
START: ptest-runner
2023-12-21T06:05
BEGIN: /usr/lib/ncurses/ptest
** with database
PASS: OK 'vt100' rc=0 err=1
PASS: OK 'dumb' rc=0 err=1
PASS: OK 'lpr' rc=-1 err=1
PASS: OK 'unknown' rc=-1 err=0
** with database
PASS: OK 'vt100' rc=0 err=1
PASS: OK 'dumb' rc=0 err=1
PASS: OK 'lpr' rc=-1 err=1
PASS: OK 'unknown' rc=-1 err=0
=== Test Summary ===
TOTAL: 8
PASSED: 8
FAILED: 0
DURATION: 1
END: /usr/lib/ncurses/ptest
2023-12-21T06:05
STOP: ptest-runner
```

[ptest-ncurses.log](https://github.com/ML-HirotakaFurukawa/meta-debian/files/13736856/ptest-ncurses.log)

## Test summary

* TOTAL: 8
  * PASS: 8
  * FAIL: 0

I executed this ptest 3 times and obtained the same results.