### PR TITLE
Add qemu config params for run ptest to deb10.13 2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       service: deby
     environment:
       PTEST_RUNNER_TIMEOUT: $PTEST_RUNNER_TIMEOUT
+      QEMU_PARAMS: $QEMU_PARAMS
     command: /home/deby/poky/meta-debian/tests/qemu_ptest.sh
 
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     environment:
       PTEST_RUNNER_TIMEOUT: $PTEST_RUNNER_TIMEOUT
       QEMU_PARAMS: $QEMU_PARAMS
+      IMAGE_ROOTFS_EXTRA_SPACE: $IMAGE_ROOTFS_EXTRA_SPACE
     command: /home/deby/poky/meta-debian/tests/qemu_ptest.sh
 
 volumes:

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,7 @@ Input params from env:
 | TEST_DISTRO_FEATURES | DISTRO_FEATURES will be used.       | "pam x11"                 |
 | PTEST_RUNNER_TIMEOUT | Timeout seconds for ptest-runner.   | "7200"                    |
 | QEMU_PARAMS          | Specify custom parameters to QEMU.  | "-smp 2 -m 2048"          |
+| IMAGE_ROOTFS_EXTRA_SPACE | Extra space(KB) of rootfs for qemu machine. | "1048576"     |
 
 Example:
 ```sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,6 +43,7 @@ Input params from env:
 | TEST_DISTROS         | Distros will be tested.             | "deby deby-tiny"          |
 | TEST_MACHINES | Machines will be tested. Only qemu machine is supported. | "qemux86 qemuarm" |
 | TEST_DISTRO_FEATURES | DISTRO_FEATURES will be used.       | "pam x11"                 |
+| PTEST_RUNNER_TIMEOUT | Timeout seconds for ptest-runner.   | "7200"                    |
 
 Example:
 ```sh
@@ -63,6 +64,7 @@ Imput params from env:
 | Variable      | Description                     | Example                   |
 | --------------| ------------------------------- | ------------------------- |
 | TEST_PACKAGES | Packages need to run ptest.     | "zlib gzip"               |
+| PTEST_RUNNER_TIMEOUT | Timeout seconds for ptest-runner. | "7200"           |
 
 Example:
 ```sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,6 +44,7 @@ Input params from env:
 | TEST_MACHINES | Machines will be tested. Only qemu machine is supported. | "qemux86 qemuarm" |
 | TEST_DISTRO_FEATURES | DISTRO_FEATURES will be used.       | "pam x11"                 |
 | PTEST_RUNNER_TIMEOUT | Timeout seconds for ptest-runner.   | "7200"                    |
+| QEMU_PARAMS          | Specify custom parameters to QEMU.  | "-smp 2 -m 2048"          |
 
 Example:
 ```sh

--- a/tests/qemu_ptest.sh
+++ b/tests/qemu_ptest.sh
@@ -13,6 +13,7 @@
 #   QEMU_PARAMS: Specify custom parameters to QEMU. Eg: "-smp 2 -m 2048"
 #     - `-smp`: Amount of CPU cores.
 #     - `-m`:   Memory size(MB). Default: 512 MB
+#   IMAGE_ROOTFS_EXTRA_SPACE: Extra space(KB) of rootfs for qemu machine.
 
 trap "exit" INT
 trap 'kill $(jobs -p)' EXIT
@@ -92,6 +93,11 @@ for distro in $TEST_DISTROS; do
 
 		note "Testing machine $machine ..."
 		set_var "MACHINE" "$machine" conf/local.conf
+
+		if [ -n "$IMAGE_ROOTFS_EXTRA_SPACE" ] && [[ "$IMAGE_ROOTFS_EXTRA_SPACE" =~ ^[0-9]+$ ]]; then
+			note "Set IMAGE_ROOTFS_EXTRA_SPACE to $IMAGE_ROOTFS_EXTRA_SPACE KB."
+			set_var "IMAGE_ROOTFS_EXTRA_SPACE" "$IMAGE_ROOTFS_EXTRA_SPACE" conf/local.conf
+		fi
 
 		bitbake core-image-minimal
 		if [ "$?" != "0" ]; then

--- a/tests/qemu_ptest.sh
+++ b/tests/qemu_ptest.sh
@@ -9,6 +9,7 @@
 #   TEST_MACHINES: machines will be tested. Eg: "qemux86 qemuarm"
 #   TEST_DISTRO_FEATURES: DISTRO_FEATURES will be used. Eg: "pam x11"
 #   TEST_ENABLE_SECURITY_UPDATE: If 1 is set, enable security update repository.
+#   PTEST_RUNNER_TIMEOUT: Timeout seconds for ptest-runner. Default: 300 seconds, Eg: 7200
 
 trap "exit" INT
 trap 'kill $(jobs -p)' EXIT
@@ -131,3 +132,4 @@ for distro in $TEST_DISTROS; do
 		ssh_qemu "/sbin/poweroff"
 	done
 done
+

--- a/tests/qemu_ptest.sh
+++ b/tests/qemu_ptest.sh
@@ -10,6 +10,9 @@
 #   TEST_DISTRO_FEATURES: DISTRO_FEATURES will be used. Eg: "pam x11"
 #   TEST_ENABLE_SECURITY_UPDATE: If 1 is set, enable security update repository.
 #   PTEST_RUNNER_TIMEOUT: Timeout seconds for ptest-runner. Default: 300 seconds, Eg: 7200
+#   QEMU_PARAMS: Specify custom parameters to QEMU. Eg: "-smp 2 -m 2048"
+#     - `-smp`: Amount of CPU cores.
+#     - `-m`:   Memory size(MB). Default: 512 MB
 
 trap "exit" INT
 trap 'kill $(jobs -p)' EXIT
@@ -97,7 +100,7 @@ for distro in $TEST_DISTROS; do
 		fi
 
 		# Boot image with QEMU
-		nohup runqemu $machine nographic slirp &
+		nohup runqemu $machine nographic slirp qemuparams="$QEMU_PARAMS" &
 
 		# Wait for SSH
 		timeout=60


### PR DESCRIPTION
# Purpose of pull request
Import QEMU parameter addition commits from meta-debian.
See [#335](https://github.com/meta-debian/meta-debian/pull/335)

When running ptest on Docker, some packages may testing fails because is not enough machine resource on QEMU machine.
That machine resouce is CPU cores, memory, and disk space.
Therefore, we add options to specify mechine resources.

Add options:

QEMU_PARAMS:
Pass to qemuparams argument of the runqemu command.
Can specify memory size, CPU cores or etc, for QEMU machine.
IMAGE_ROOTFS_EXTRA_SPACE:
Extra space(KB) of rootfs for qemu machine.
Set to IMAGE_ROOTFS_EXTRA_SPACE of conf/local.conf.

# Testing
## Prepare testing
Modify the tests/qemu_ptest.sh file for check machine resource on the QEMU machine as follows:
```diff
diff --git a/tests/qemu_ptest.sh b/tests/qemu_ptest.sh
index 436ac993..9d31a181 100755
--- a/tests/qemu_ptest.sh
+++ b/tests/qemu_ptest.sh
@@ -128,6 +128,11 @@ for distro in $TEST_DISTROS; do
                        fi
                done
 
+               # Check CPU core, memory and strage on QEMU machine
+               ssh_qemu 'echo CPUs: $(grep processor /proc/cpuinfo | wc -l)'
+               ssh_qemu "free"
+               ssh_qemu "df"
+
                # Run ptest
                scp_qemu $THISDIR/run_ptest.sh $TEST_USER@$TEST_IPADDR:/tmp/ > /dev/null
                ssh_qemu "VERBOSE=$VERBOSE PTEST_RUNNER_TIMEOUT='$PTEST_RUNNER_TIMEOUT' TEST_PACKAGES='$TEST_PACKAGES' $EXTRA_ENV /tmp/run_ptest.sh"
```

## How to test
Set the environment variables and run qemu_ptest.
```
export TEST_PACKAGES="openssh"
export TEST_DISTROS="deby"
export TEST_MACHINES="qemuarm64"
export COMPOSE_HTTP_TIMEOUT=7200
export PTEST_RUNNER_TIMEOUT=7200
export TEST_DISTRO_FEATURES="pam"
export QEMU_PARAMS="-smp 4 -m 8192"
export IMAGE_ROOTFS_EXTRA_SPACE=2097152
cd ./docker
make qemu_ptest
```

## Test result
The added messages is displayed, and machine resource (CPU cores, memory, and storage) is configured on QEMU machine as expected.
```
docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: openssh
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 2097152 KB.
Parsing recipes: 100% |##########################################################################################################################################################################################################################################| Time: 0:00:43
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 58 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-qemu-config-params-for-run-ptest-to-deb10.13-2:08138edbf81aa90025693b81717fbab4d3a4b17b"

Initialising tasks: 100% |#######################################################################################################################################################################################################################################| Time: 0:00:04
Sstate summary: Wanted 850 Found 0 Missed 850 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2953 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 4 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (6s / 60s)
NOTE: Waiting for SSH to be ready... (17s / 60s)
NOTE: Waiting for SSH to be ready... (22s / 60s)
stdin: is not a tty
CPUs: 4
stdin: is not a tty
              total        used        free      shared  buff/cache   available
Mem:        8172272       44580     8106840           0       20852     8029732
Swap:             0           0           0
stdin: is not a tty
Filesystem     1K-blocks   Used Available Use% Mounted on
/dev/root        2128684 189908   1805172  10% /
devtmpfs         4069112      0   4069112   0% /dev
stdin: is not a tty
Running ptest for openssh ...
openssh: PASS/SKIP/FAIL = 35/7/1
stdin: is not a tty
```
