### PR TITLE
coreutils: Add RRECOMMENDS setting

### DIFF
--- a/recipes-debian/coreutils/coreutils_debian.bb
+++ b/recipes-debian/coreutils/coreutils_debian.bb
@@ -146,6 +146,12 @@ BBCLASSEXTEND = "native nativesdk"
 
 inherit ptest
 
+# -dev automatic dependencies fails as we don't want libmodule-build-perl-dev, its too heavy
+# # may need tweaking if DEPENDS changes
+# # Can't use ${PN}-dev here since flags with overrides and key expansion not supported
+RRECOMMENDS_coreutils-dev[nodeprrecs] = "1"
+RRECOMMENDS_${PN}-dev += "acl-dev attr-dev gmp-dev libcap-dev bash-dev findutils-dev gawk-dev shadow-dev"
+
 RDEPENDS_${PN}-ptest += "bash findutils gawk liberror-perl make perl perl-modules python3-core sed shadow"
 
 do_install_ptest () {


### PR DESCRIPTION
Added RRECOMMENDS variables to fix sdk build error. According to the[ poky's coreutils recipe](
https://git.yoctoproject.org/poky/tree/meta/recipes-core/coreutils/coreutils_9.4.bb), it needs to set RRECOMMENDS for dependency issue.

```
# -dev automatic dependencies fails as we don't want libmodule-build-perl-dev, its too heavy
# may need tweaking if DEPENDS changes
# Can't use ${PN}-dev here since flags with overrides and key expansion not supported
RRECOMMENDS:coreutils-dev[nodeprrecs] = "1"
RRECOMMENDS:${PN}-dev += "acl-dev attr-dev gmp-dev libcap-dev bash-dev findutils-dev gawk-dev shadow-dev"
```


Build core-image-minimal-sdk success.

```
$ bitbake core-image-minimal-sdk -c populate_sdk
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:17
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2384 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-coreutils:1a52e264d5434fd23f907f6d01d3458f5512a595"
meta-debian-extended = "fix-sdk-build-weston:10363b9d8599ef5e40b301af0e350abc7d09afd1"
meta-emlinux         = "HEAD:6e7588a4c66b68d457c62b22ea50ab82ac53e7de"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 829 Found 0 Missed 829 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3395 tasks of which 0 didn't need to be rerun and all succeeded.
```

Build core-image-weston-sdk  success.

```
$ bitbake core-image-weston-sdk -c populate_sdk
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:17
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2384 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-coreutils:a3078cbf4b2d5fa0a1dab5e9fd931cdb862e4461"
meta-debian-extended = "fix-sdk-build-weston:10363b9d8599ef5e40b301af0e350abc7d09afd1"
meta-emlinux         = "HEAD:6e7588a4c66b68d457c62b22ea50ab82ac53e7de"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:02
Sstate summary: Wanted 1269 Found 0 Missed 1269 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5200 tasks of which 0 didn't need to be rerun and all succeeded.
```
