### PR TITLE
curl: Add CVE-2021-22926 to whitelist

### DIFF
--- a/recipes-debian/curl/curl_debian.bb
+++ b/recipes-debian/curl/curl_debian.bb
@@ -15,6 +15,9 @@ PR = "r1"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;beginline=8;md5=3a34942f4ae3fbf1a303160714e664ac"
 
+# CVE-2021-22926: only affects builds for MacOS.
+CVE_CHECK_WHITELIST = "CVE-2021-22926"
+
 inherit autotools pkgconfig binconfig multilib_header
 
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} gnutls proxy threaded-resolver zlib"


### PR DESCRIPTION
CVE-2021-22926 only affects builds for MacOS.
So, add it to CVE_CHECK_WHITELIST.

https://nvd.nist.gov/vuln/detail/CVE-2021-22926
https://security-tracker.debian.org/tracker/CVE-2021-22926

From Poky rev: 462de8f86f25b482145853ccbb5601fde28ab7da