### PR TITLE
cmake: Set nativesdk to BBCLASSEXTEND

### DIFF
--- a/recipes-debian/cmake/cmake_debian.bb
+++ b/recipes-debian/cmake/cmake_debian.bb
@@ -54,3 +54,5 @@ FILES_${PN}_append_class-nativesdk = " ${SDKPATHNATIVE}"
 FILES_${PN} += "${datadir}/cmake-${CMAKE_MAJOR_VERSION} ${datadir}/cmake ${datadir}/aclocal"
 FILES_${PN}-doc += "${docdir}/cmake-${CMAKE_MAJOR_VERSION}"
 FILES_${PN}-dev = ""
+
+BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
# Purpose of pull request
Set nativesdk to BBCLASSEXTEND in cmake's recipe, because debian source code is not used when building the nativesdk-cmake.

Without the definition, different versions of cmake will be generated depending on the recipe at poky/meta/recipes-devtools/cmake/cmake_3.14.1.bb.

Before applying this patch:
```
  build$ bitbake core-image-minimal -c populate_sdk
  ...
  build$ find ./ | grep 'build/bin/cmake'
  ./tmp/work/aarch64-deby-linux/cmake/3.13.4-r0/build/bin/cmake
  ./tmp/work/x86_64-linux/cmake-native/3.13.4-r0/build/bin/cmake
  ./tmp/work/x86_64-nativesdk-debysdk-linux/nativesdk-cmake/3.14.1-r0/build/bin/cmake
```

# Test
1. Build package
2. Check the files generated by cmake build
   - Settings to local.conf
     Add the following to local.conf.
     ```
     DISTRO = "deby"
     MACHINE = "qemuarm64"
     IMAGE_INSTALL_append = " cmake"
     ```
     (optional) Set MIRROR to local.conf if necessary.
     ```
     MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20230920T232020Z/pool/updates/ \n"
     MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20231010T220613Z/pool/updates/ \n"
     MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20231218T230659Z/pool/updates/ \n"
     ```

   - Build command
     ```
     $ bitbake core-image-minimal -c populate_sdk
     ```

   - Check files command
     ```
     $ find ./ | grep 'build/bin/cmake'
     ```

## Test result
### Build package
Build succeeded.
```
$ bitbake core-image-minimal -c populate_sdk
Parsing recipes: 100% |#######################################################################################| Time: 0:01:02
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 73 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-nativesdk-to-BBCLASSEXTEND:077687f39d4d4a7957e85cc95071c25a0741a8b5"

Initialising tasks: 100% |####################################################################################| Time: 0:00:03
Sstate summary: Wanted 823 Found 0 Missed 823 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3363 tasks of which 0 didn't need to be rerun and all succeeded.
```

### Check files
The version of nativesdk-cmake is correct.
```
$ find ./ | grep 'build/bin/cmake'
./tmp/work/x86_64-linux/cmake-native/3.13.4-r0/build/bin/cmake
./tmp/work/aarch64-deby-linux/cmake/3.13.4-r0/build/bin/cmake
./tmp/work/x86_64-nativesdk-debysdk-linux/nativesdk-cmake/3.13.4-r0/build/bin/cmake
```