### PR TITLE
cmake: Add CVE-2016-10642 to whitelist

### DIFF
--- a/recipes-debian/cmake/cmake.inc
+++ b/recipes-debian/cmake/cmake.inc
@@ -17,3 +17,7 @@ SRC_URI += " \
     file://0003-cmake-support-OpenEmbedded-Qt4-tool-binary-names.patch \
     file://0004-Fail-silently-if-system-Qt-installation-is-broken.patch \
 "
+
+# This is specific to the npm package that installs cmake, so isn't
+# relevant to OpenEmbedded
+CVE_CHECK_WHITELIST += "CVE-2016-10642"


### PR DESCRIPTION
This CVE is specific to the npm package that can install cmake,
so isn't relevant to our cmake recipe.

https://nvd.nist.gov/vuln/detail/CVE-2016-10642
https://security-tracker.debian.org/tracker/CVE-2016-10642

Referenced from Poky rev: c68c4aa22c86b91b5f2c7c4c175c7ad7b38105c7