### PR TITLE
Fix ptest fails caused by inability to resolve localhost name

### DIFF
--- a/recipes-debian/glib-2.0/glib-2.0_debian.bb
+++ b/recipes-debian/glib-2.0/glib-2.0_debian.bb
@@ -22,3 +22,5 @@ SRC_URI += " \
     file://glib-meson.cross \
 "
 SRC_URI_append_class-natve = "file://relocate-modules.patch"
+
+RDEPENDS_${PN}-ptest += "netbase"

--- a/recipes-debian/netbase/netbase_debian.bb
+++ b/recipes-debian/netbase/netbase_debian.bb
@@ -25,3 +25,32 @@ do_install () {
 }
 
 CONFFILES_${PN} = "${sysconfdir}/hosts"
+
+# Base on debian/netbase.postinst
+pkg_postinst_${PN}() {
+    create_hosts_file() {
+        if [ -e $D${sysconfdir}/hosts ]; then return 0; fi
+
+        cat > $D${sysconfdir}/hosts <<-EOF
+	127.0.0.1	localhost
+	::1		localhost ip6-localhost ip6-loopback
+	ff02::1		ip6-allnodes
+	ff02::2		ip6-allrouters
+
+EOF
+    }
+
+    create_networks_file() {
+        if [ -e $D${sysconfdir}/networks ]; then return 0; fi
+
+        cat > $D${sysconfdir}/networks <<-EOF
+	default		0.0.0.0
+	loopback	127.0.0.0
+	link-local	169.254.0.0
+
+EOF
+    }
+
+    create_hosts_file
+    create_networks_file
+}

--- a/recipes-debian/openssh/openssh_debian.bb
+++ b/recipes-debian/openssh/openssh_debian.bb
@@ -150,7 +150,7 @@ FILES_${PN}-keygen = "${bindir}/ssh-keygen"
 RDEPENDS_${PN} += "${PN}-scp ${PN}-ssh ${PN}-sshd ${PN}-keygen"
 RDEPENDS_${PN}-sshd += "${PN}-keygen ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam-plugin-keyinit pam-plugin-loginuid', '', d)}"
 RRECOMMENDS_${PN}-sshd_append_class-target = " rng-tools"
-RDEPENDS_${PN}-ptest += "${PN}-sftp ${PN}-misc ${PN}-sftp-server make sed sudo coreutils"
+RDEPENDS_${PN}-ptest += "${PN}-sftp ${PN}-misc ${PN}-sftp-server make sed sudo coreutils netbase"
 
 RPROVIDES_${PN}-ssh = "ssh"
 RPROVIDES_${PN}-sshd = "sshd"

--- a/recipes-debian/python/python3_debian.bb
+++ b/recipes-debian/python/python3_debian.bb
@@ -299,7 +299,7 @@ FILES_${PN}-misc = "${libdir}/python${PYTHON_MAJMIN} ${libdir}/python${PYTHON_MA
 PACKAGES += "${PN}-man"
 FILES_${PN}-man = "${datadir}/man"
 
-RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip bzip2 libgcc tzdata-europe coreutils sed"
+RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip bzip2 libgcc tzdata-europe coreutils sed netbase"
 RDEPENDS_${PN}-ptest_append_libc-glibc = " locale-base-tr-tr.iso-8859-9"
 RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk tk-lib', '', d)}"
 RDEPENDS_${PN}-dev = ""

--- a/recipes-debian/python/python_debian.bb
+++ b/recipes-debian/python/python_debian.bb
@@ -186,7 +186,7 @@ FILES_${PN}-misc = "${libdir}/python${PYTHON_MAJMIN}"
 RDEPENDS_${PN}-modules += "${PN}-misc"
 
 # ptest
-RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip tzdata-europe coreutils sed"
+RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip tzdata-europe coreutils sed netbase"
 RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk', '', d)}"
 # catch manpage
 PACKAGES += "${PN}-man"


### PR DESCRIPTION
# Purpose of pull request

Ptests for some packages fail because they cannot resolve the localhost name.
See https://github.com/meta-debian/meta-debian/issues/332

Fixed follows for resolve that issue:
- netbase: Install /etc/hosts and /etc/networks
  Add the pkg_postinst_${PN}() function to netbase recipe.
- Add netbase to RDEPENDS for ptest
  For following packages:
  - openssh
  - python3
  - python
  - glib-2.0

# Test
1. Build test
2. Functional test

## Build test
### How to build test
Set the environment variables and run build_test.
```
export TEST_ENABLE_SECURITY_UPDATE="1"
export TEST_PACKAGES="netbase openssh python3 python glib-2.0"
export TEST_DISTROS="deby"
export TEST_MACHINES="qemuarm64"
export COMPOSE_HTTP_TIMEOUT=7200
export PTEST_RUNNER_TIMEOUT=7200
cd docker/
make build_test
```

### Build test result
All package builds were successful.
```
meta-debian/docker$ make build_test
docker-compose run --rm build_test
WARNING: The QEMU_PARAMS variable is not set. Defaulting to a blank string.
WARNING: The IMAGE_ROOTFS_EXTRA_SPACE variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: These recipes will be tested: netbase openssh python3 python glib-2.0
NOTE: Building netbase ...
NOTE: Build netbase: PASS
NOTE: Building openssh ...
NOTE: Build openssh: PASS
NOTE: Building python3 ...
NOTE: Build python3: PASS
NOTE: Building python ...
NOTE: Build python: PASS
NOTE: Building glib-2.0 ...
NOTE: Build glib-2.0: PASS
```

## Functional test
### How to functional test
1. Build qemuarm64 image
   Add the following to local.conf and build qemuarm64 image.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   IMAGE_INSTALL_append = " netbase"
   ```
   ```
   $ bitbake core-image-minimal
   ```

2. Run qemu image
   ```
   $ runqemu qemuarm64 nographic
   ```

3. Run some commands
   ```
   # cat /etc/hosts
   # cat /etc/networks
   # ping -c 4 localhost
   ```

### Functional test result
The /etc/hosts and /etc/networks files exist and the ping command to localhost was successful.
```
# cat /etc/hosts
127.0.0.1	localhost
::1		localhost ip6-localhost ip6-loopback
ff02::1		ip6-allnodes
ff02::2		ip6-allrouters

# cat /etc/networks
default		0.0.0.0
loopback	127.0.0.0
link-local	169.254.0.0

# ping -c 4 localhost
PING localhost (127.0.0.1): 56 data bytes
64 bytes from 127.0.0.1: seq=0 ttl=64 time=1.399 ms
64 bytes from 127.0.0.1: seq=1 ttl=64 time=1.347 ms
64 bytes from 127.0.0.1: seq=2 ttl=64 time=0.730 ms
64 bytes from 127.0.0.1: seq=3 ttl=64 time=0.929 ms

--- localhost ping statistics ---
4 packets transmitted, 4 packets received, 0% packet loss
round-trip min/avg/max = 0.730/1.101/1.399 ms
```