### PR TITLE
Add ptest for tar

### DIFF
--- a/recipes-debian/tar/tar/0001-Fix-the-difflink-test.patch
+++ b/recipes-debian/tar/tar/0001-Fix-the-difflink-test.patch
@@ -1,0 +1,37 @@
+From 1ed62596cf859b73612abe8eb35616413ec5613c Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org>
+Date: Fri, 28 Dec 2018 17:53:35 +0200
+Subject: [PATCH] Fix the difflink test
+
+Hardlinking a symlink produces hardlink on BSD and symlink
+on GNU/Linux. Avoid the ambiguity.
+
+* tests/difflink.at: Create hard link from a regular file.
+---
+ tests/difflink.at | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/difflink.at b/tests/difflink.at
+index 2de035c..5d86ba0 100644
+--- a/tests/difflink.at
++++ b/tests/difflink.at
+@@ -20,14 +20,14 @@ AT_TAR_CHECK([
+ mkdir a
+ genfile -f a/x
+ ln -s x a/y
+-ln -P a/y a/z
++ln a/x a/z
+ tar cf a.tar a/x a/y a/z
+ rm a/z
+ ln -s x a/z
+ tar df a.tar
+ ],
+ [1],
+-[a/z: Not linked to a/y
++[a/z: Not linked to a/x
+ ],
+ [],
+ [],[],[ustar]) # Testing one format is enough
+-- 
+2.25.1
+

--- a/recipes-debian/tar/tar/run-ptest
+++ b/recipes-debian/tar/tar/run-ptest
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Define tar test work dir
+WORKDIR=@PTEST_PATH@/tests/
+
+# Run test
+cd ${WORKDIR}
+./atconfig ./atlocal ./testsuite
+
+# clear log
+rm -rf testsuite.dir
+rm -rf testsuite.log
+
+./testsuite --am-fmt

--- a/recipes-debian/tar/tar_debian.bb
+++ b/recipes-debian/tar/tar_debian.bb
@@ -52,6 +52,37 @@ do_install_append_libc-musl() {
 	rmdir ${D}${libdir}
 }
 
+# add for ptest support
+SRC_URI += " \
+    file://run-ptest \
+"
+
+inherit ptest
+
+do_compile_ptest() {
+    oe_runmake -C ${B}/gnu/ check
+    oe_runmake -C ${B}/lib/ check
+    oe_runmake -C ${B}/rmt/ check
+    oe_runmake -C ${B}/src/ check
+    rm -rf ${S}/tests/testsuite
+    oe_runmake -C ${B}/tests/ testsuite
+    oe_runmake -C ${B}/tests/ genfile checkseekhole ckmtime
+}
+
+do_install_ptest() {
+    install -d ${D}${PTEST_PATH}/tests/
+    install --mode=755 ${B}/tests/atconfig ${D}${PTEST_PATH}/tests/
+    sed -i "/abs_/d" ${D}${PTEST_PATH}/tests/atconfig
+    echo "abs_builddir=${PTEST_PATH}/tests/" >> ${D}${PTEST_PATH}/tests/atconfig
+    install --mode=755 ${B}/tests/atlocal ${D}${PTEST_PATH}/tests/
+    sed -i "/PATH=/d" ${D}${PTEST_PATH}/tests/atlocal
+    install --mode=755 ${B}/tests/genfile ${D}${PTEST_PATH}/tests/
+    install --mode=755 ${B}/tests/checkseekhole ${D}${PTEST_PATH}/tests/
+    install --mode=755 ${B}/tests/ckmtime ${D}${PTEST_PATH}/tests/
+    install --mode=755 ${S}/tests/testsuite ${D}${PTEST_PATH}/tests/
+    sed -i "s#@PTEST_PATH@#${PTEST_PATH}#g" ${D}${PTEST_PATH}/run-ptest
+}
+
 PACKAGES =+ "${PN}-rmt"
 
 FILES_${PN}-rmt = "${base_sbindir}/rmt*"

--- a/recipes-debian/tar/tar_debian.bb
+++ b/recipes-debian/tar/tar_debian.bb
@@ -105,3 +105,4 @@ NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"
 BBCLASSEXTEND = "native nativesdk"
 
 CVE_PRODUCT = "gnu:tar"
+RDEPENDS_${PN}-ptest += "bash"

--- a/recipes-debian/tar/tar_debian.bb
+++ b/recipes-debian/tar/tar_debian.bb
@@ -55,6 +55,7 @@ do_install_append_libc-musl() {
 # add for ptest support
 SRC_URI += " \
     file://run-ptest \
+    file://0001-Fix-the-difflink-test.patch \
 "
 
 inherit ptest


### PR DESCRIPTION
# Purpose of pull request

Add ptest referenced from Poky-master:
- 4f2ccdb9 tar: Add ptest support

And, fixed to all tests pass:
- 4fe34925 tar: Add bash to RDEPENDS for ptest
- e52fd5e8 tar: Add patch for pass the difflink test of ptest

# Test
Run ptest of tar package on docker of meta-debian

## How to run ptest of tar package
1. Prepare environment variables
   ```
   export TEST_PACKAGES="tar"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   export COMPOSE_HTTP_TIMEOUT=7200
   export PTEST_RUNNER_TIMEOUT=7200
   export QEMU_PARAMS="-smp 4 -m 4096"
   export IMAGE_ROOTFS_EXTRA_SPACE=1048576
   ```

2. Run ptest on docker of meta-debian
   ```
   cd docker
   make qemu_ptest
   ```

## Test result
All tests were successful.
```
meta-debian/docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: tar
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 1048576 KB.
Parsing recipes: 100% |######################################################################################################################| Time: 0:00:37
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-ptest-for-tar:e52fd5e8f59eeea8b15dacce076520d5f2016a67"

Initialising tasks: 100% |###################################################################################################################| Time: 0:00:03
Sstate summary: Wanted 818 Found 0 Missed 818 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2861 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 4 -m 4096"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (17s / 60s)
stdin: is not a tty
Running ptest for tar ...
tar: PASS/SKIP/FAIL = 197/26/0
stdin: is not a tty
```
```
meta-debian/docker$ tail ../tests/logs/deby/qemuarm64/tar.ptest.log 
## ------------- ##
## Test results. ##
## ------------- ##

197 tests were successful.
26 tests were skipped.
DURATION: 1276
END: /usr/lib/tar/ptest
2024-03-28T13:34
STOP: ptest-runner
```