### PR TITLE
openssh: Add CVE-2023-51767 to whitelist

### DIFF
--- a/recipes-debian/openssh/openssh_debian.bb
+++ b/recipes-debian/openssh/openssh_debian.bb
@@ -163,3 +163,8 @@ ALTERNATIVE_${PN}-scp = "scp"
 ALTERNATIVE_${PN}-ssh = "ssh"
 
 BBCLASSEXTEND += "nativesdk"
+
+# Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and
+# does not intent to address it in OpenSSH
+# https://security-tracker.debian.org/tracker/CVE-2023-51767
+CVE_CHECK_WHITELIST += "CVE-2023-51767"


### PR DESCRIPTION
# Purpose of pull request

This PR adds CVE-2023-51767 to whitelist.

Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and does not intent to address it in OpenSSH.
So, add it to CVE_CHECK_WHITELIST.

* NVD: https://nvd.nist.gov/vuln/detail/CVE-2023-51767
* DST : https://security-tracker.debian.org/tracker/CVE-2023-51767
* Upstream Bugzilla : https://bugzilla.mindrot.org/show_bug.cgi?id=3656

This PR backports the following commit from poky's kirkstone:

* [a095c9e6a3](https://github.com/yoctoproject/poky/commit/a095c9e6a349ecf5e73e74d05cb6a815877155bf) openssh: Add CVE-2023-51767 to CVE_CHECK_IGNORE

# Note

CVE-2023-51767 affects all versions of openssh.
However poky-warrior's cve-check can't handle "all version" information because https://github.com/yoctoproject/poky/commit/cae5e155a8b597930d600e1c24a5f73e69489be6 is not backported.

As a result, we can't detect CVE-2023-51767 in `DISTRO=deby` even if it is not in whitelist.

```
$ bitbake openssh -c cve_check
...(snip)...
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-poky
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:f2f5924ad05daa780fcd690779d8477eb6379196"

Initialising tasks: 100% |########################################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: openssh-7.9p1-r0 do_cve_check: Found unpatched CVE (CVE-2016-20012 CVE-2020-14145 CVE-2020-15778 CVE-2021-36368 CVE-2021-41617 CVE-2023-38408 CVE-2023-48795 CVE-2023-51384 CVE-2023-51385), for more information check /home/meta-sasaki/deby-bsp/build/tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

Therefore, the test was performed in `DISTRO=emlinux` instead of `DISTRO=deby`.

```
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "openssh-ignore-CVE-2023-51767:19d7b7df29d679ca190ab6fd5ae1a948658e1eab"
meta-debian-extended = "HEAD:70c70ad07593449f5c074402c4d7ddee86e7c6d8"
meta-emlinux         = "HEAD:4692d49c49bc3497467c23f908a74d2f0434848e"
```

# Test
## How to test

Add the following line into local.conf.

```
INHERIT += "cve-check"
```

And then run the following command.

```
$ bitbake openssh -c cve_check
```

Confirm CVE-2023-51767 is not detected.

## Test result

Before this PR:

```
$ bitbake openssh -c cve_check
...(snip)...
WARNING: openssh-7.9p1-r0 do_cve_check: Found unpatched CVE (CVE-2007-2768 CVE-2008-3844 CVE-2014-9278 CVE-2016-20012 CVE-2020-14145 CVE-2020-15778 CVE-2021-36368 CVE-2021-41617 CVE-2023-38408 CVE-2023-48795 CVE-2023-51384 CVE-2023-51385 CVE-2023-51767), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/openssh/7.9p1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

After this PR, CVE-2023-51767 is not shown:

```
meta-sasaki@D1-raytrek-01:~/eml-bsp/build$ bitbake openssh -c cve_check
...(snip)...
WARNING: openssh-7.9p1-r0 do_cve_check: Found unpatched CVE (CVE-2007-2768 CVE-2008-3844 CVE-2014-9278 CVE-2016-20012 CVE-2020-14145 CVE-2020-15778 CVE-2021-36368 CVE-2021-41617 CVE-2023-38408 CVE-2023-48795 CVE-2023-51384 CVE-2023-51385), for more information check /home/meta-sasaki/eml-bsp/build/tmp-glibc/work/aarch64-emlinux-linux/openssh/7.9p1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```