### PR TITLE
nss: Add CVE-2006-5201 to whiltelist

### DIFF
--- a/recipes-debian/nss/nss_debian.bb
+++ b/recipes-debian/nss/nss_debian.bb
@@ -263,3 +263,5 @@ FILES_${PN}-dev = "\
 
 BBCLASSEXTEND = "native nativesdk"
 
+# CVE-2006-5201: only affects for Sun Solaris.
+CVE_CHECK_WHITELIST += "CVE-2006-5201"


### PR DESCRIPTION
# Purpose of pull request

CVE-2006-5201 is for Sun Solaris only. So, add it to CVE_CHECK_WHITELIST.

# Test
## How to test

Add following line into conf/local.conf.

```
INHERIT += "cve-check"
```

And then run following command.

```
$ bitbake nss -c cve_check
```

## Test result

Before this commit, it showed the following warning:

```
$ bitbake nss -c cve_check
...(snip)...
NOTE: Executing RunQueue Tasks
WARNING: nss-3.42.1-r0 do_cve_check: Found unpatched CVE (CVE-2006-5201), for more information check /home/miracle/work/emlinux-2.9-202405/build-qemuarm64/tmp-glibc/work/aarch64-emlinux-linux/nss/3.42.1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```

After this commit, CVE-2006-5201 is not shown:

```
$ bitbake nss -c cve_check
...(snip)...
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```
