### PR TITLE
Change source repository to freexian to deb10.13 2

### DIFF
--- a/conf/distro/deby.inc
+++ b/conf/distro/deby.inc
@@ -11,6 +11,9 @@ TARGET_VENDOR = "-deby"
 # is now necessary to pull updates by Debian LTS
 DEBIAN_SECURITY_UPDATE_MIRROR ?= "http://security.debian.org/debian-security/pool/updates"
 
+# Extended LTS Updates for Debian 10 Buster
+DEBIAN_ELTS_SECURITY_UPDATE_MIRROR ?= "http://deb.freexian.com/extended-lts/pool"
+
 # Add an eventhandler that generates DEBIAN_SRC_URI information
 # from Debian apt repository.
 INHERIT += "debian-source"

--- a/doc/2.components.md
+++ b/doc/2.components.md
@@ -36,7 +36,7 @@ This task runs after `do_debian_unpack_extra` and before `do_patch`.
 This is an eventhandler, defined by `debian-source.bbclass`
 to generate Debian package source code information: `PV`, `URI`, `checksum`.
 These kinds of information are fetched from
-`dists/buster/main/source/Sources.xz` in Debian apt repository.
+`dists/buster/main/source/Sources.gz` in Debian apt repository.
 This eventhandler runs when `bb.event.ParseStarted` is fired.
 
 Variables

--- a/doc/3.development/3.1.create_recipe.md
+++ b/doc/3.development/3.1.create_recipe.md
@@ -16,7 +16,7 @@ When bitbake run, class `debian-source` will generate information
 about version, source URI and checksum to `.inc` file.
 
 *NOTE: By default, `debian-source` will not rerun if
-file `Sources.xz` does not change. Force it regenerate by adding
+file `Sources.gz` does not change. Force it regenerate by adding
 `DEBIAN_SRC_FORCE_REGEN = "1"` into `conf/local.conf` in the build directory.*
 
 Write recipe

--- a/doc/3.development/3.2.example.md
+++ b/doc/3.development/3.2.example.md
@@ -9,7 +9,7 @@ Assume we want to create recipe for `icu`.
 
    # Enable debian-source
    echo 'DEBIAN_SOURCE_ENABLED = "1"' >> <build-dir>/conf/local.conf
-   # Force debian-source re-generate in case Sources.xz doesn't change
+   # Force debian-source re-generate in case Sources.gz doesn't change
    echo 'DEBIAN_SRC_FORCE_REGEN = "1"' >> <build-dir>/conf/local.conf
    ```
 

--- a/doc/6.security-update.md
+++ b/doc/6.security-update.md
@@ -4,7 +4,7 @@ When debian package is updated because of security issue and you want to update 
 
 # Preparation
 
-If build image with docker or test scripts(tests/build_test or tests/qemu_ptest) and you already created docker image, please rebuild it. 
+If build image with docker or test scripts(tests/build_test or tests/qemu_ptest) and you already created docker image, please rebuild it.
 If you haven't created docker image, please see README.md to setup it.
 
 If you don't use test scripts, yon need to install python3-debian package.
@@ -25,7 +25,7 @@ export TEST_ENABLE_SECURITY_UPDATE="1"
 
 Also, you want to set other variables e.g. TEST_MACHINES, TEST_DISTROS, and so on.
 
-Then,  you can build with docker. 
+Then, you can build with docker.
 
 ```
 $ make -C ../docker build_test
@@ -44,7 +44,11 @@ DEBIAN_SRC_FORCE_REGEN = "1"
 
 DEBIAN_SECURITY_UPDATE_ENABLED = "1"
 DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
+DEBIAN_ELTS_SECURITY_UPDATE_MIRROR = "http://deb.freexian.com/extended-lts/pool"
 ```
+
+DEBIAN_SECURITY_UPDATE_MIRROR specifies the LTS update repository.
+DEBIAN_ELTS_SECURITY_UPDATE_MIRROR specifies the ELTS update repository.
 
 Then, run bitbake command e.g. bitbake -f core-image minimal -c clean.
 
@@ -60,6 +64,7 @@ DEBIAN_SRC_FORCE_REGEN = "1"
 ```
 
 Before you run bitbake command, DEBIAN_SRC_URI uses DEBIAN_SECURITY_UPDATE_MIRROR as a debian mirror server.
+Similar for DEBIAN_ELTS_SECURITY_UPDATE_MIRROR.
 
 ```
     DEBIAN_SRC_URI = " \
@@ -88,8 +93,9 @@ DEBIAN_SOURCE_ENABLED = "1"
 DEBIAN_SRC_FORCE_REGEN = "1"
 ```
 
-Be careful, if package still use DEBIAN_SECURITY_UPDATE_MIRROR as a mirror server, you need following lines in your conf/local.conf to fetch source packages.
+Be careful, if package still use DEBIAN_SECURITY_UPDATE_MIRROR or DEBIAN_ELTS_SECURITY_UPDATE_MIRROR as a mirror server, you need following lines in your conf/local.conf to fetch source packages.
 
 ```
 DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
+DEBIAN_ELTS_SECURITY_UPDATE_MIRROR = "http://deb.freexian.com/extended-lts/pool"
 ```

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -168,4 +168,5 @@ function get_all_packages {
 
 function setup_security_update_repository() {
 	set_var "DEBIAN_SECURITY_UPDATE_MIRROR" "http://security.debian.org/debian-security/pool/updates" conf/local.conf
+	set_var "DEBIAN_ELTS_SECURITY_UPDATE_MIRROR" "http://deb.freexian.com/extended-lts/pool" conf/local.conf
 }


### PR DESCRIPTION
# Purpose of pull request
Debian buster's LTS (long term support) will end on June 30th, 2024.
After that, ELTS (extended long term support) will be provided by Freexian.

See: https://www.freexian.com/lts/extended/

So add DEBIAN_ELTS_SECURITY_UPDATE_MIRROR variable and modified it to target the
ELTS repository.

# Test
## How to test
### Confirm target repositores test
1. Test in Deby's docker environment.
   ```
   meta-debian$ cd docker/
   meta-debian/docker$ make start
   ```

2. Setup build environment within Deby's docker.
   `DEBIAN_SECURITY_UPDATE_MIRROR` and `DEBIAN_ELTS_SECURITY_UPDATE_MIRROR` are defined in ./conf/distro/deby.inc.
   ```
   source poky/meta-debian/tests/common.sh
   setup_builddir
   echo 'MACHINE = "qemuarm64"' >> ./conf/local.conf
   echo 'DISTRO = "deby"' >> ./conf/local.conf
   echo 'DEBIAN_SOURCE_ENABLED = "1"' >> ./conf/local.conf
   echo 'DEBIAN_SRC_FORCE_REGEN = "1"' >> ./conf/local.conf
   echo 'DEBIAN_SECURITY_UPDATE_ENABLED = "1"' >> ./conf/local.conf
   ```

3. Run command
   ```
   bitbake core-image-minimal -c clean
   ```

### Update *.inc files test
1. Add setting
   Following on from the previous test, add setting.
   Currently, the contents of `DEBIAN_SECURITY_UPDATE_MIRROR` and `DEBIAN_ELTS_SECURITY_UPDATE_MIRROR` are the same, so specify the old repository for `DEBIAN_SECURITY_UPDATE_MIRROR`.
   ```
   echo 'DEBIAN_SECURITY_UPDATE_MIRROR="http://snapshot.debian.org/archive/debian-security/20240401T105543Z/pool/updates"' >> ./conf/local.conf
   ```

2. Run commands and check updates
   ```
   bitbake core-image-minimal -c clean
   cd ../poky/meta-debian/
   git status
   git diff | head -n 20
   ```

# Test result
## Confirm target repositores test
The Release and Sources.gz files reference from `DEBIAN_SECURITY_UPDATE_MIRROR` and `DEBIAN_ELTS_SECURITY_UPDATE_MIRROR` repositories defined in ./conf/distro/deby.inc.

```
deby@8a39326c628d:~/build$ bitbake core-image-minimal -c clean
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=0ccbd79d7dfd84b9ed8cc16cac1d36da
Parsing Debian Sources.gz ...
Checking Debian Release ... http://security.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://security.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=493669e8274757740d8fe5aea79afd5f
Parsing Debian Sources.gz ...
Checking Debian Release ... http://ftp.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://ftp.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:29
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "change-source-repository-to-freexian-to-deb10.13-2:6a9688e7b6c3b26b625582962ac3af3bfa97d849"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

### Update *.inc files test
Confirmed that it has been rewritten to `${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}`.
```diff
deby@8a39326c628d:~/build$ bitbake core-image-minimal -c clean
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=ee7474e3237a33b69335142596fe929a
Parsing Debian Sources.gz ...
Checking Debian Release ... http://snapshot.debian.org/archive/debian-security/20240401T105543Z/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://snapshot.debian.org/archive/debian-security/20240401T105543Z/dists/buster/updates/main/source/Sources.gz;md5sum=884b67333c97dbd99314908394602d2f
Parsing Debian Sources.gz ...
Checking Debian Release ... http://ftp.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://ftp.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:21
...snip...
deby@8a39326c628d:~/build$ cd ../poky/meta-debian/
deby@8a39326c628d:~/poky/meta-debian$ git status
On branch change-source-repository-to-freexian-to-deb10.13-2
Your branch is up to date with 'teradat/change-source-repository-to-freexian-to-deb10.13-2'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   recipes-debian/sources/expat.inc
	modified:   recipes-debian/sources/glib2.0.inc
	modified:   recipes-debian/sources/glibc.inc
	modified:   recipes-debian/sources/tzdata.inc
	modified:   recipes-debian/sources/util-linux.inc

no changes added to commit (use "git add" and/or "git commit -a")
deby@8a39326c628d:~/poky/meta-debian$ git diff | head -n 20
diff --git a/recipes-debian/sources/expat.inc b/recipes-debian/sources/expat.inc
index dc82c526..94212604 100644
--- a/recipes-debian/sources/expat.inc
+++ b/recipes-debian/sources/expat.inc
@@ -5,9 +5,9 @@ REPACK_PV = "2.2.6"
 PV = "2.2.6"
 
 DEBIAN_SRC_URI = " \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/e/expat/expat_2.2.6-2+deb10u7.dsc;name=expat_2.2.6-2+deb10u7.dsc \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/e/expat/expat_2.2.6.orig.tar.gz;name=expat_2.2.6.orig.tar.gz \
-    ${DEBIAN_SECURITY_UPDATE_MIRROR}/main/e/expat/expat_2.2.6-2+deb10u7.debian.tar.xz;name=expat_2.2.6-2+deb10u7.debian.tar.xz \
+    ${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}/main/e/expat/expat_2.2.6-2+deb10u7.dsc;name=expat_2.2.6-2+deb10u7.dsc \
+    ${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}/main/e/expat/expat_2.2.6.orig.tar.gz;name=expat_2.2.6.orig.tar.gz \
+    ${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}/main/e/expat/expat_2.2.6-2+deb10u7.debian.tar.xz;name=expat_2.2.6-2+deb10u7.debian.tar.xz \
 "
 
 SRC_URI[expat_2.2.6-2+deb10u7.dsc.md5sum] = "b0ae8a37c637b9b49e02ec9de548fd45"
diff --git a/recipes-debian/sources/glib2.0.inc b/recipes-debian/sources/glib2.0.inc
index 082583c5..e469a11d 100644
--- a/recipes-debian/sources/glib2.0.inc
```