### PR TITLE
gnutls: Add ptest support

### DIFF
--- a/recipes-debian/gnutls/gnutls/0001-Extend-test-cert-to-2049-05-27.patch
+++ b/recipes-debian/gnutls/gnutls/0001-Extend-test-cert-to-2049-05-27.patch
@@ -1,0 +1,58 @@
+From a27b914a6ed9c01bcee85c1b8d748a6b094caa05 Mon Sep 17 00:00:00 2001
+From: "Bernhard M. Wiedemann" <bwiedemann@suse.de>
+Date: Sun, 14 Apr 2019 16:53:52 +0200
+Subject: [PATCH] Extend test cert to 2049-05-27
+
+instead of expiring in 2024-02-29
+This update did not trigger y2038 bugs on 32-bit systems.
+
+Without this patch, one test fails after 2024:
+ doit:124: rsa pss key: gnutls_x509_crt_verify_data2                    |
+ FAIL x509sign-verify (exit status: 1)
+
+Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>
+---
+ tests/cert-common.h | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/tests/cert-common.h b/tests/cert-common.h
+index 80cdffd77..86aeb5c92 100644
+--- a/tests/cert-common.h
++++ b/tests/cert-common.h
+@@ -940,7 +940,7 @@ static char server_ca3_rsa_pss_cert_pem[] =
+ 	"-----BEGIN CERTIFICATE-----\n"
+ 	"MIIEAjCCAjqgAwIBAgIMWSa+iBMb7BVvI0GIMD0GCSqGSIb3DQEBCjAwoA0wCwYJ\n"
+ 	"YIZIAWUDBAIBoRowGAYJKoZIhvcNAQEIMAsGCWCGSAFlAwQCAaIDAgEgMA8xDTAL\n"
+-	"BgNVBAMTBENBLTMwHhcNMDQwMjI5MTUyMTQyWhcNMjQwMjI5MTUyMTQxWjANMQsw\n"
++	"BgNVBAMTBENBLTMwHhcNMTkwNDE1MDkyMjIwWhcNNDkxMjMxMDkyMjIwWjANMQsw\n"
+ 	"CQYDVQQGEwJHUjCCAVIwPQYJKoZIhvcNAQEKMDCgDTALBglghkgBZQMEAgGhGjAY\n"
+ 	"BgkqhkiG9w0BAQgwCwYJYIZIAWUDBAIBogMCASADggEPADCCAQoCggEBAL8TnzAG\n"
+ 	"W6iLlapD7ebOX8jXrmA9Pa/NKAxDeeDEu/7TMvtspK8LF92tcxi6p+O0OfRNEAJY\n"
+@@ -951,15 +951,15 @@ static char server_ca3_rsa_pss_cert_pem[] =
+ 	"8dZ4FgVEOYQRuSUCAwEAAaNQME4wDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUjFqe\n"
+ 	"vO9heHT9V24WV1ovs7pvUvMwHwYDVR0jBBgwFoAU+aiGGWO2pBQTYHYPAZo1Nu/x\n"
+ 	"tK8wPQYJKoZIhvcNAQEKMDCgDTALBglghkgBZQMEAgGhGjAYBgkqhkiG9w0BAQgw\n"
+-	"CwYJYIZIAWUDBAIBogMCASADggGBABg5Cmmo0jrs+mTT5cTOozda9zSIe+rH6NxQ\n"
+-	"xms99hYvMiTv6RENR3DzJqNhQAvQkFrOpW+rnXRDROmETc8TYaX1pgbwZUCldTaZ\n"
+-	"c+2zybs3p3/yHFmVc39IWD2I5CbUxIHils9zM1BNvBaeoLTqX/BfNv+VBglDKF4/\n"
+-	"x4mUozoInwAYHjQGBKXPkZbITq6tYJ0uF8TjMS6bbqDSrUvvCNjX9fQ8IUQ0zRyk\n"
+-	"HHgVV/zrQT47yOOE6MkWrnCGob9vKAxWtVsPmoc5DQnh/nFIu8mWPMKMjeMNASNa\n"
+-	"9VqE1DlAadOP/WDEmrGiMB8Gf1MqYEMhwsMBh3AorrE7Y31sM6K+mJ8P6e0jS+rl\n"
+-	"++MtMqoNcvH9LAP1Tu6sRTw0kbXuz+GvDiQq0BEHxQIriK7luO3Z9nLOf/joyIMZ\n"
+-	"DYzEnfIkmL9zQqtfyeh+KQYGQwt3SiucRPhB05AvW68RZ4QaAJ1aSNot1vUpth4U\n"
+-	"dPVrVe13NnAP8tV4a8PisLaz9fHLnA==\n"
++	"CwYJYIZIAWUDBAIBogMCASADggGBAAgVZdGqSwhaa8c/KuqsnELoK5QlzdSUNZ0O\n"
++	"J31nVQyOmIJtqR14nMndU0y1iowAoj0osZFYjxjN6e2AqUF7R22uhtxmG6rr0YEi\n"
++	"XS+rNpbs7+gY/3hK30vo376QL85+U4v4HuTCd+yX8bY9VPqwZBMYO5rcDyXG82xC\n"
++	"ZKXT/Tr7XD80iMFjyR2cvRAjoZQeXbWzNE4AEm0jNz2F5Qnl6uSgtpDkHYKgr9xq\n"
++	"yUhm/WNKG86pzBxfcFju4prqBLiwUZh068b6znBAS0wMflrF/lznu01QqDhK6mz3\n"
++	"cSn5LlzoKjuouAWdZRieqokr1mNiWggmX5n2qKM9FJtDQctsvntCf/freAfy+Xmu\n"
++	"Tm055R9UzX76mL89eXY92U++HR8Y5IO5lqY1f13rzWK5rJB9qjz/Mamj9xR6Egoa\n"
++	"hh1ysRItcTCFJI5xKb/i3hHv94U12EH1IfFHofptr1pyCtAeOhJytWPndCiB2m1q\n"
++	"M2k3tl6cHvlUz7DpgnxNniuQ/dQ4MA==\n"
+ 	"-----END CERTIFICATE-----\n";
+ 
+ const gnutls_datum_t server_ca3_rsa_pss_cert = { (unsigned char*)server_ca3_rsa_pss_cert_pem,
+-- 
+2.25.1
+

--- a/recipes-debian/gnutls/gnutls/Add-ptest-support.patch
+++ b/recipes-debian/gnutls/gnutls/Add-ptest-support.patch
@@ -1,0 +1,54 @@
+From 6abc86acecff5a30173eb78a971ec5b65f77e1de Mon Sep 17 00:00:00 2001
+From: Ravineet Singh <ravineet.a.singh@est.tech>
+Date: Tue, 10 Jan 2023 16:11:10 +0100
+Subject: [PATCH] gnutls: add ptest support
+
+Upstream-Status: Inappropriate [embedded specific]
+Signed-off-by: Ravineet Singh <ravineet.a.singh@est.tech>
+---
+ Makefile.am       | 3 +++
+ configure.ac      | 2 ++
+ tests/Makefile.am | 6 ++++++
+ 3 files changed, 11 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index b4d0db3..37788f7 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -180,4 +180,7 @@ dist-hook: libopts-check symbol-check
+ 	mv ChangeLog $(distdir)
+ 	touch $(distdir)/doc/*.html $(distdir)/doc/*.pdf $(distdir)/doc/*.info
+ 
++install-ptest:
++	$(MAKE) -C tests DESTDIR=$(DESTDIR)/tests $@
++
+ .PHONY: abi-check abi-dump pic-check symbol-check local-code-coverage-output files-update libopts-check AUTHORS
+diff --git a/configure.ac b/configure.ac
+index b686726..1eeb4aa 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -903,6 +903,8 @@ AC_SUBST(LIBGNUTLS_CFLAGS)
+ 
+ AM_CONDITIONAL(NEEDS_LIBRT, test "$gnutls_needs_librt" = "yes")
+ 
++AM_EXTRA_RECURSIVE_TARGETS([buildtest-TESTS])
++
+ AC_DEFINE([GNUTLS_COMPAT_H], 1, [Make sure we don't use old features in code.])
+ AC_DEFINE([GNUTLS_INTERNAL_BUILD], 1, [We allow temporarily usage of deprecated functions - until they are removed.])
+ 
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index cf3b22a..0850770 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -552,5 +552,11 @@ if WANT_TEST_SUITE
+ LOG_COMPILER = $(VALGRIND)
+ endif
+ 
++install-ptest: $(check_PROGRAMS)
++	@$(INSTALL) -d $(DESTDIR)
++	@for file in $^; do \
++		$(INSTALL_PROGRAM) $$file $(DESTDIR) ; \
++	done
++
+ distclean-local:
+ 	rm -rf softhsm-*.db softhsm-*.config *.tmp tmp-* x509-crt-list-import-url.config.db

--- a/recipes-debian/gnutls/gnutls/run-ptest
+++ b/recipes-debian/gnutls/gnutls/run-ptest
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+rjob() {
+    local job=$1
+    local log=$2
+
+    # TODO: Output will be garbled
+    ./${job} >> ${log} 2>&1
+
+    ret=$?
+    case $ret in
+    0)
+        echo "PASS: $t" >> ${log}
+        echo "PASS: $t"
+        ;;
+    77)
+        echo "SKIP: $t" >> ${log}
+        echo "SKIP: $t"
+        ;;
+    *)
+        echo "FAIL: $t" >> ${log}
+        echo "FAIL: $t"
+        ;;
+    esac
+}
+
+is_disallowed() {
+    local key=$1
+    $(echo ${test_disallowlist} | grep -w -q ${key})
+    return $?
+}
+
+# TODO
+# This list should probably be in a external file
+# Testcases defined here either take very long time (dtls-stress)
+# or are dependent on local files (certs, etc) in local file system
+# currently not exported to target.
+
+test_disallowlist=""
+test_disallowlist="${test_disallowlist} dtls-stress"
+test_disallowlist="${test_disallowlist} handshake-large-cert"
+test_disallowlist="${test_disallowlist} id-on-xmppAddr"
+test_disallowlist="${test_disallowlist} mini-x509-cas"
+test_disallowlist="${test_disallowlist} pkcs12_simple"
+test_disallowlist="${test_disallowlist} protocol-set-allowlist"
+test_disallowlist="${test_disallowlist} psk-file"
+test_disallowlist="${test_disallowlist} rawpk-api"
+test_disallowlist="${test_disallowlist} set_pkcs12_cred"
+test_disallowlist="${test_disallowlist} system-override-curves-allowlist"
+test_disallowlist="${test_disallowlist} system-override-hash"
+test_disallowlist="${test_disallowlist} system-override-sig"
+test_disallowlist="${test_disallowlist} system-override-sig-tls"
+test_disallowlist="${test_disallowlist} system-prio-file"
+test_disallowlist="${test_disallowlist} x509cert-tl"
+
+LOG=${PWD}/tests.log
+cd tests
+max_njobs=$(grep -c ^processor /proc/cpuinfo)
+njobs=0
+
+set +e
+
+for t in *; do
+    [ -x $t ] || continue
+    [ -f $t ] || continue
+
+    is_disallowed ${t}
+    [ $? -eq 0 ] && continue
+
+    rjob ${t} ${LOG} &
+    one=1
+    njobs=$(expr ${njobs} + ${one})
+    if [ ${njobs} -eq ${max_njobs} ]; then
+        wait
+        njobs=0
+    fi
+done
+wait
+
+skipped=$(grep -c SKIP ${LOG})
+passed=$(grep -c PASS ${LOG})
+failed=$(grep -c FAIL ${LOG})
+total=$(expr ${passed} + ${failed} + ${skipped})
+
+if [ ${failed} -ne 0 ]; then
+    echo
+    echo "Tests failed for gnutls, log is:"
+    echo "--------------------"
+    cat ${LOG}
+    echo
+fi
+
+echo
+echo "gnutls test summary:"
+echo "--------------------"
+echo "total: ${total}"
+echo "pass : ${passed}"
+echo "fail : ${failed}"
+echo "skip : ${skipped}"
+echo

--- a/recipes-debian/gnutls/gnutls_debian.bb
+++ b/recipes-debian/gnutls/gnutls_debian.bb
@@ -21,9 +21,15 @@ require recipes-debian/sources/gnutls28.inc
 DEPENDS = "nettle gmp virtual/libiconv libunistring"
 DEPENDS_append_libc-musl = " argp-standalone"
 
-SRC_URI += "file://arm_eabi.patch"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += " \
+    file://arm_eabi.patch \
+    file://run-ptest \
+    file://Add-ptest-support.patch \
+    file://0001-Extend-test-cert-to-2049-05-27.patch \
+"
 
-inherit autotools texinfo pkgconfig gettext lib_package gtk-doc
+inherit autotools texinfo pkgconfig gettext lib_package gtk-doc ptest
 
 PACKAGECONFIG ??= "libidn"
 
@@ -54,10 +60,16 @@ do_configure_prepend() {
 	done
 }
 
+do_compile_ptest() {
+    oe_runmake -C tests buildtest-TESTS
+}
+
 PACKAGES =+ "${PN}-openssl ${PN}-xx"
 
 FILES_${PN}-dev += "${bindir}/gnutls-cli-debug"
 FILES_${PN}-openssl = "${libdir}/libgnutls-openssl.so.*"
 FILES_${PN}-xx = "${libdir}/libgnutlsxx.so.*"
+
+RDEPENDS_${PN}-ptest += "python3"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Purpose of pull request
Add ptest for gnutls.

Referred from Poky-master's commit:
  - [a08c791bae](https://git.yoctoproject.org/poky/commit/?id=a08c791bae13bda56ee71e9023329473e8d5baa5) gnutls: add ptest support
  - [647b9ddb33](https://git.yoctoproject.org/poky/commit/?id=647b9ddb33d950340c6edac75883531418b937e2) gnutls: Add missing python ptest dependency
  - [04dc2e5311](https://git.yoctoproject.org/poky/commit/?id=04dc2e53112bb31437f4688d7fc9df9ad2497c76) gnutls: clean up ptest compilation
  - [20b1e729e1](https://git.yoctoproject.org/poky/commit/?id=20b1e729e1b4d39c245b4e12729f239ff4342062) gnutls: print log if ptest fails

And, referred from gnutls's commit:
  - [a27b914a6](https://gitlab.com/gnutls/gnutls/-/commit/a27b914a6ed9c01bcee85c1b8d748a6b094caa05) Extend test cert to 2049-05-27

# Test
Run ptest of gnutls package on docker of meta-debian

## How to run ptest of gnutls package
1. Prepare environment variables
   ```
   export TEST_PACKAGES="gnutls"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   export COMPOSE_HTTP_TIMEOUT=7200
   export PTEST_RUNNER_TIMEOUT=7200
   export QEMU_PARAMS="-smp 4 -m 8192"
   export IMAGE_ROOTFS_EXTRA_SPACE=2097152
   ```

2. Run ptest on docker of meta-debian
   ```
   cd docker
   make qemu_ptest
   ```

## Test result
Tests were successful, without failures.
```
meta-debian/docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
WARNING: The TEST_ENABLE_SECURITY_UPDATE variable is not set. Defaulting to a blank string.
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: gnutls
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 2097152 KB.
Parsing recipes: 100% |#################################################################################################| Time: 0:00:30
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-gnutls-ptest-support-to-deb10.13-2:39fd4e77862ea7161baa967248cdd6221b62487e"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 842 Found 0 Missed 842 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2934 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 4 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (7s / 60s)
NOTE: Waiting for SSH to be ready... (12s / 60s)
NOTE: Waiting for SSH to be ready... (17s / 60s)
NOTE: Waiting for SSH to be ready... (22s / 60s)
stdin: is not a tty
Running ptest for gnutls ...
gnutls: PASS/SKIP/FAIL = 330/6/0
stdin: is not a tty
```

For reference information:
```
meta-debian/docker$ grep -A 30 summary ../tests/logs/deby/qemuarm64/gnutls.ptest.log 
gnutls test summary:
--------------------
total: 336
pass : 330
fail : 0
skip : 6

DURATION: 693
END: /usr/lib/gnutls/ptest
2024-08-20T06:24
STOP: ptest-runner
```
```
meta-debian/docker$ grep 'SKIP' ../tests/logs/deby/qemuarm64/gnutls.ptest.log 
SKIP: fips-mode-pthread
SKIP: fips-override-test
SKIP: fips-test
SKIP: ssl30-cert-key-exchange
SKIP: ssl30-cipher-neg
SKIP: ssl30-server-kx-neg
```