### PR TITLE
kbd: Fix reference path in ptest

### DIFF
--- a/recipes-debian/kbd/kbd_debian.bb
+++ b/recipes-debian/kbd/kbd_debian.bb
@@ -46,6 +46,11 @@ do_install_ptest() {
 	    -e 's:${S}/config/missing::g' \
 	    -e 's:${WORKDIR}::g' \
 	    -e '/libkeymap_.*_SOURCES =/d' -e '/$(EXEEXT):/,/^$/d' \
+	    -e '/^VPATH/s/= .*$/= ../g' \
+	    -e '/^abs_srcdir/s/= .*$/= ../g' \
+	    -e '/^abs_top_srcdir/s/= .*$/= ../g' \
+	    -e '/^srcdir/s/= .*$/= ../g' \
+	    -e '/^top_srcdir/s/= .*$/= ../g' \
 	    ${D}${PTEST_PATH}/tests/Makefile
 
 	find ${B}/tests -executable -exec install {} ${D}${PTEST_PATH}/tests \;
@@ -60,6 +65,8 @@ FILES_${PN}-consolefonts = "${datadir}/consolefonts"
 FILES_${PN}-consoletrans = "${datadir}/consoletrans"
 FILES_${PN}-keymaps = "${datadir}/keymaps"
 FILES_${PN}-unimaps = "${datadir}/unimaps"
+
+RDEPENDS_${PN}-ptest += " make bash coreutils"
 
 inherit update-alternatives
 


### PR DESCRIPTION
# Purpose of pull request

The following error occurred because the reference path was incorrect in ptest.
  ```
  make[1]: Entering directory '/usr/lib/kbd/ptest/tests'
  /bin/bash: ../../kbd-2.0.4/config/test-driver: No such file or directory
  make[1]: *** [Makefile:912: libkeymap-init.log] Error 127
  ```

Fixed that error, and added necessary packages to RDEPENDS to run ptest.

# Test
Run ptest of kbd package on docker of meta-debian

## How to run ptest of kbd package
1. Prepare environment variables
   ```
   export TEST_PACKAGES="kbd"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   export COMPOSE_HTTP_TIMEOUT=7200
   export PTEST_RUNNER_TIMEOUT=7200
   ```

2. Run ptest on docker of meta-debian
   ```
   cd docker
   make qemu_ptest
   ```

## Test result
All tests were successful.
```
meta-debian/docker$ make qemu_ptest 
docker-compose run --rm qemu_ptest
WARNING: The QEMU_PARAMS variable is not set. Defaulting to a blank string.
WARNING: The IMAGE_ROOTFS_EXTRA_SPACE variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
WARNING: The TEST_ENABLE_SECURITY_UPDATE variable is not set. Defaulting to a blank string.
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: kbd
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:30
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-kbd-ptest:55848d49e55a43a097ccb79a24d0e9732aa742b3"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:02
Sstate summary: Wanted 830 Found 0 Missed 830 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2897 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams=""`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (6s / 60s)
NOTE: Waiting for SSH to be ready... (11s / 60s)
NOTE: Waiting for SSH to be ready... (16s / 60s)
NOTE: Waiting for SSH to be ready... (21s / 60s)
NOTE: Waiting for SSH to be ready... (26s / 60s)
NOTE: Waiting for SSH to be ready... (31s / 60s)
stdin: is not a tty
Running ptest for kbd ...
kbd: PASS/SKIP/FAIL = 7/0/0
stdin: is not a tty
```
```
meta-debian/docker$ cat ../tests/logs/deby/qemuarm64/kbd.ptest.log 
START: ptest-runner
ERROR: Unable to detach from controlling tty, Inappropriate ioctl for device
2024-10-11T07:52
BEGIN: /usr/lib/kbd/ptest
make: Entering directory '/usr/lib/kbd/ptest/tests'
make[1]: Entering directory '/usr/lib/kbd/ptest/tests'
PASS: libkeymap-init
PASS: libkeymap-kmap
PASS: libkeymap-keys
PASS: libkeymap-parse
PASS: libkeymap-charset
PASS: dumpkeys-fulltable
PASS: alt-is-meta
============================================================================
Testsuite summary for kbd 2.0.4
============================================================================
# TOTAL: 7
# PASS:  7
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/kbd/ptest/tests'
make: Leaving directory '/usr/lib/kbd/ptest/tests'
DURATION: 25
END: /usr/lib/kbd/ptest
2024-10-11T07:52
STOP: ptest-runner
```