### PR TITLE
debian-cve-check: Workaround DST database received error

### DIFF
--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -70,7 +70,7 @@ python update_dst () {
             return
         except Exception as e:
             bb.debug(2, "DST database: received error (%s), retrying" % (e))
-            time.sleep(attempt * 3)
+            time.sleep(10 + (attempt * 10))
             continue
     else:
         bb.error("DST database received error")


### PR DESCRIPTION
# Purpose of pull request

Receiving DST database fails because server [1] returns 504 or 503.
As a workaround, extend retry interval.

[1] https://deb.freexian.com/extended-lts/tracker/data/json

# Test
## How to test
1. local.conf setting
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   INHERIT += " cve-check debian-cve-check"
   ```

2. Run cve-check
   Run cve-check without dst.json file.
   ```
   $ rm -f downloads/CVE_CHECK/DEBIAN/dst.json 
   $ bitbake bash -c cve_check
   ```

3.  Check log.do_populate_cve_db
Check `tmp/work/x86_64-linux/cve-update-db-native/1.0-r0/temp/log.do_populate_cve_db` file.

## Test result
### Before this PR
Failed to receive DST database, and error on cve-check.

Build log:
```
build$ bitbake bash -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:44
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.13-2:868f80ca2353de271b95d72b80bbc9fb87dcffa4"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
ERROR: cve-update-db-native-1.0-r0 do_populate_cve_db: DST database received error
ERROR: bash-5.0-r0 do_cve_check: /<PATH-TO>/build/downloads/CVE_CHECK/DEBIAN/dst.json dosen't exist
ERROR: bash-5.0-r0 do_cve_check: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:debian_cve_check(d)
     0003:
File: '/<PATH-TO>/poky/meta-debian/classes/debian-cve-check.bbclass', lineno: 32, function: debian_cve_check
     0028:            _pkg_file_name = os.path.basename(_pkg_uri)
     0029:            pkgname = _pkg_file_name.split(";")[0].split("_")[0]
     0030:            break
     0031:
 *** 0032:    if pkgname not in dst_data.keys():
     0033:        bb.note("%s is not found in Debian Security Tracker." % pkgname)
     0034:        return
     0035:
     0036:    deb_patched, deb_unpatched = deb_check_cves(d, dst_data[pkgname])
Exception: AttributeError: 'NoneType' object has no attribute 'keys'

ERROR: bash-5.0-r0 do_cve_check: 'NoneType' object has no attribute 'keys'
ERROR: bash-5.0-r0 do_cve_check: Function failed: debian_cve_check
ERROR: Logfile of failure stored in: /<PATH-TO>/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/log.do_cve_check.30346
ERROR: Task (/<PATH-TO>/poky/meta-debian/recipes-debian/bash/bash_debian.bb:do_cve_check) failed with exit code '1'
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /<PATH-TO>/poky/meta-debian/recipes-debian/bash/bash_debian.bb:do_cve_check
Summary: There were 5 ERROR messages shown, returning a non-zero exit code.
```

Check log.do_populate_cve_db:
```
build$ cat tmp/work/x86_64-linux/cve-update-db-native/1.0-r0/temp/log.do_populate_cve_db
DEBUG: Executing python function do_populate_cve_db
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
ERROR: DST database received error
DEBUG: Python function update_dst finished
```

### After this PR
After retry, DST database received successfully and cve-check executed.

Build log:
```
build$ bitbake bash -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:42
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "workaround-debian-cve-check:37fc7674d7f983082f0868e7e95c53670c8d2189"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /<PATH-TO>/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

Check log.do_populate_cve_db:
```
build$ cat ./tmp/work/x86_64-linux/cve-update-db-native/1.0-r0/temp/log.do_populate_cve_db
DEBUG: Executing python function do_populate_cve_db
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database updated
DEBUG: Python function update_dst finished
```