### PR TITLE
Allow changing the security tracker's URL

### DIFF
--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -9,6 +9,7 @@
 
 DEBIAN_CVE_CHECK_DB_DIR ?= "${CVE_CHECK_DB_DIR}/DEBIAN"
 DEBIAN_CODENAME ?= "${DISTRO_CODENAME}"
+DEBIAN_SECRUTY_TRACKER_JSON_URL ??= "https://deb.freexian.com/extended-lts/tracker/data/json"
 
 python debian_cve_check () {
     """
@@ -50,7 +51,7 @@ python update_dst () {
     import time
     from datetime import datetime, date
 
-    json_url = "https://deb.freexian.com/extended-lts/tracker/data/json"
+    json_urls = d.getVar("DEBIAN_SECRUTY_TRACKER_JSON_URL", "").split(" ")
     dist_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
     dist_dir = os.path.dirname(dist_path)
 
@@ -62,16 +63,21 @@ python update_dst () {
         if timestamp.date() == date.today():
             return
 
-    for attempt in range(5):
-        try:
-            with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
-                shutil.copyfileobj(response, f)
-            bb.debug(2, "DST database updated")
-            return
-        except Exception as e:
-            bb.debug(2, "DST database: received error (%s), retrying" % (e))
-            time.sleep(10 + (attempt * 10))
-            continue
+    for json_url in json_urls:
+        bb.note("Download json file from %s" % json_url)
+        for attempt in range(5):
+            try:
+                with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
+                    shutil.copyfileobj(response, f)
+                bb.debug(2, "DST database updated")
+                return
+            except ValueError as e:
+                bb.warn("Invalid URL (%s)" % (e))
+                break
+            except Exception as e:
+                bb.debug(2, "DST database: received error (%s), retrying" % (e))
+                time.sleep(10 + (attempt * 10))
+                continue
     else:
         bb.error("DST database received error")
         return

--- a/doc/7.cve-check.md
+++ b/doc/7.cve-check.md
@@ -1,0 +1,24 @@
+# CVE Check feature
+
+The CVE check feature is based on Poky's CVE check functionality and uses NVD vulnerability information. However, the fixed versions listed in NVD vulnerability information may not match Debian package versions. As a result, relying solely on NVD vulnerability information could lead to Debian packages that have already been patched being mistakenly identified as unpatched. To address this issue, the CVE check feature in meta-debian utilizes Debian vulnerability information to eliminate false positives.
+
+# Variable
+
+- DEBIAN\_SECRUTY\_TRACKER\_JSON\_URL
+
+Debian 10 reached the end of LTS support in June 2024 and has been maintained as ELTS by Freexian since July 2024. Therefore, vulnerability information for Debian packages is sourced from the data provided by Freexian. However, retrieving vulnerability information from this server may sometimes fail, preventing the CVE check from being performed.
+
+To address this issue, users can now configure a mirror server to be used when downloading vulnerability information from Freexian's server fails. The ```DEBIAN_SECURITY_TRACKER_JSON_URL``` variable is set by default to Freexian's server URL, but users can modify its value or add additional URLs as needed. This setting can be in conf/local.conf or other file.
+
+Append URL:
+
+```
+DEBIAN_SECRUTY_TRACKER_JSON_URL_append = " http://localhost:8000/dst.json"
+```
+
+Replace URL:
+
+```
+DEBIAN_SECRUTY_TRACKER_JSON_URL = "http://localhost:8000/dst.json"
+```
+


### PR DESCRIPTION
# Purpose

Downloading the security information JSON file from Freexian's server sometimes fails due to server errors, such as HTTP status 504 or 503. Therefore, this commit allow user can change its URL or append fallback URL to their mirror server.
This setting can be in conf/local.conf or other file.

When you want to setup your own mirror,  json file name can be anything.

e.g.
Use _append to variable.

```
DEBIAN_SECRUTY_TRACKER_JSON_URL_append = "
http://localhost:8000/dst.json"
```

Change URL.

```
DEBIAN_SECRUTY_TRACKER_JSON_URL = "http://localhost:8000/dst.json"
```

# Test

Add following lines to conf/local.conf.

```
DISTRO = "deby"
MACHINE = "qemuarm64"
INHERIT += " cve-check debian-cve-check"
```

Run cve-check following command.

```
rm -fr downloads/CVE_CHECK/DEBIAN/dst.json ; bitbake busybox -c cve_check
```

## default setting

Test test use default setting.

It fails 3 times then succeeded to get data from Freexian.

```
build@buster:~/metadebian/build$ cat  tmp/work/x86_64-linux/cve-update-db-native/1.0-r0/temp/log.do_populate_cve_db
DEBUG: Executing python function do_populate_cve_db
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
NOTE: Download json file from https://deb.freexian.com/extended-lts/tracker/data/json
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database updated
DEBUG: Python function update_dst finished
```

## Append mirror server

This test added following line in conf/local.conf.

```
DEBIAN_SECRUTY_TRACKER_JSON_URL_append = " http://localhost:8000/dst.json"
```

To test this case,  I changed retry limit in the update_dst().

```
for attempt in range(5)
```

to 

```
for attempt in range(1)
```

When download failed from Freexian, it tried to get json file from next server.

```
build@buster:~/metadebian/build$ cat  tmp/work/x86_64-linux/cve-update-db-native/1.0-r0/temp/log.do_populate_cve_db 
DEBUG: Executing python function do_populate_cve_db
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
NOTE: Download json file from https://deb.freexian.com/extended-lts/tracker/data/json
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
NOTE: Download json file from http://localhost:8000/dst.json
DEBUG: DST database updated
DEBUG: Python function update_dst finished
```

## Replace default url

This test added following line in conf/local.conf.

```
DEBIAN_SECRUTY_TRACKER_JSON_URL = " http://localhost:8000/dst.json"
```

It uses localhost to get json file instead of Freexian.

```
build@buster:~/metadebian/build$ cat  tmp/work/x86_64-linux/cve-update-db-native/1.0-r0/temp/log.do_populate_cve_db 
DEBUG: Executing python function do_populate_cve_db
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
NOTE: Download json file from http://localhost:8000/dst.json
DEBUG: DST database updated
DEBUG: Python function update_dst finished
```