### PR TITLE
Add CVE-2013-2617 and CVE-2018-13684 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/curl/curl_debian.bb
+++ b/recipes-debian/curl/curl_debian.bb
@@ -108,3 +108,7 @@ RRECOMMENDS_lib${BPN} += "ca-certificates"
 FILES_${PN} += "${datadir}/zsh"
 
 BBCLASSEXTEND = "native nativesdk"
+
+# CVE-2013-2617: It's false positive because it was mistakenly detected as
+#                RubyGem's module.
+CVE_CHECK_WHITELIST = "CVE-2013-2617"

--- a/recipes-debian/zip/zip_debian.bb
+++ b/recipes-debian/zip/zip_debian.bb
@@ -41,3 +41,7 @@ BBCLASSEXTEND = "native"
 
 # exclude version 2.3.2 which triggers a false positive
 UPSTREAM_CHECK_REGEX = "^zip(?P<pver>(?!232).+)\.tgz"
+
+# CVE-2018-13684: It's false positive because the flaw is not caused by this
+#                 package.
+CVE_CHECK_WHITELIST = "CVE-2018-13684"


### PR DESCRIPTION
Mitigates unpatched CVE messages printed for curl and zip due to false possible issues.