### PR TITLE
openssh: Add CVE-2025-32728.patch

### DIFF
--- a/recipes-debian/openssh/openssh/CVE-2025-32728.patch
+++ b/recipes-debian/openssh/openssh/CVE-2025-32728.patch
@@ -1,0 +1,41 @@
+From fc86875e6acb36401dfc1dfb6b628a9d1460f367 Mon Sep 17 00:00:00 2001
+From: "djm@openbsd.org" <djm@openbsd.org>
+Date: Wed, 9 Apr 2025 07:00:03 +0000
+Subject: [PATCH] upstream: Fix logic error in DisableForwarding option. This
+ option
+
+was documented as disabling X11 and agent forwarding but it failed to do so.
+Spotted by Tim Rice.
+
+OpenBSD-Commit-ID: fffc89195968f7eedd2fc57f0b1f1ef3193f5ed1
+
+CVE: CVE-2025-32728
+Upstream-status: Backport [ https://github.com/openssh/openssh-portable/commit/fc86875e6acb36401dfc1dfb6b628a9d1460f367 ]
+Signed-off-by: Takahiro Terada <takahiro.terada@miraclelinux.com>
+---
+ session.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/session.c b/session.c
+index 19f3863..f2b3f57 100644
+--- a/session.c
++++ b/session.c
+@@ -2182,7 +2182,8 @@ session_auth_agent_req(struct ssh *ssh, Session *s)
+ 
+ 	packet_check_eom();
+ 	if (!auth_opts->permit_agent_forwarding_flag ||
+-	    !options.allow_agent_forwarding) {
++	    !options.allow_agent_forwarding ||
++	    options.disable_forwarding) {
+ 		debug("%s: agent forwarding disabled", __func__);
+ 		return 0;
+ 	}
+@@ -2568,7 +2569,7 @@ session_setup_x11fwd(struct ssh *ssh, Session *s)
+ 		packet_send_debug("X11 forwarding disabled by key options.");
+ 		return 0;
+ 	}
+-	if (!options.x11_forwarding) {
++	if (!options.x11_forwarding || options.disable_forwarding) {
+ 		debug("X11 forwarding disabled in server configuration file.");
+ 		return 0;
+ 	}

--- a/recipes-debian/openssh/openssh_debian.bb
+++ b/recipes-debian/openssh/openssh_debian.bb
@@ -31,6 +31,7 @@ SRC_URI += " \
            file://fix-potential-signed-overflow-in-pointer-arithmatic.patch \
            file://sshd_check_keys \
            file://add-test-support-for-busybox.patch \
+           file://CVE-2025-32728.patch \
            "
 PAM_SRC_URI = "file://sshd"
 


### PR DESCRIPTION
# Purpose of pull request

Backported a fix commit from upstream to fix CVE-2025-32728 and added a patch.

# Test

- Build package
- Operation check of CVE-2025-32728 fix
- Run ptest

## How to test

- Prepare Deby build environment
- Build package and cve-check
- Build qemuarm64 image
- Operation check of CVE-2025-32728 fix
- Run ptest

### Prepare Deby build environment

Enter to docker container for Deby build.
```
poky/meta-debian/docker$ make start
docker-compose run work
...<snip>...
Creating docker_work_run ... done
```

Setup to build environment.
```
deby@<CONTAINER-ID>:~$ export TEMPLATECONF=meta-debian/conf
deby@<CONTAINER-ID>:~$ source ./poky/oe-init-build-env
```

### Build package and cve-check

Add the following to local.conf and build package.
```
MACHINE = "qemuarm64"
DISTRO = "deby"
INHERIT += " cve-check debian-cve-check"
```

### Build qemuarm64 image and run QEMU image

Add the following to local.conf and build qemuarm64 image.
```
MACHINE = "qemuarm64"
DISTRO = "deby"
IMAGE_INSTALL_append = " openssh openssh-ptest"
```
```
$ bitbake core-image-minimal
```

Run qemuarm64 image.
```
$ runqemu qemuarm64 nographic
```

### Operation check of CVE-2025-32728 fix
#### Prepare server(sshd) side settings

On QEMU machine.

1. Once after QEMU startup

   Stop sshd daemon.
   ```
   # /etc/init.d/sshd stop
   ```

2. `/etc/ssh/sshd_config` setting

   Copy the original file to restore the settings later.
   ```
   # cp -a /etc/ssh/sshd_config /etc/ssh/sshd_config.orig
   # echo 'DisableForwarding yes' >> /etc/ssh/sshd_config
   # echo 'AllowAgentForwarding yes' >> /etc/ssh/sshd_config
   # echo 'X11Forwarding yes' >> /etc/ssh/sshd_config
   ```

3. Create `/etc/default/ssh` 

   ```
   # echo 'SSHD_OPTS="-d -E /root/sshd.log"' > /etc/default/ssh
   ```

4. Start sshd daemon

   Delete log and start sshd daemon.
   ```
   # rm -f /root/sshd.log
   # /etc/init.d/sshd start
   ```

5. Check log after testing operation on client side 

   ```
   # grep -i forward /root/sshd.log
   ```

#### Client side operations
1. Start new terminal and enter to Deby docker container

   Enter the running server-side Docker container.
   ```
   $ docker ps
   $ docker exec -it <CONTAINER-ID> bash
   ```

2. Testing Agent Forwarding

   - Run ssh-agent
     ```
     $ eval "$(ssh-agent)"
     ```

   - Run ssh with agent-forwarding connect to sshd on QEMU
     ```
     $ ssh -A root@192.168.7.2
     ```

   - Run any command and exit
     ```
     # ls
     # exit
     ```

3. Testing X11 Forwarding

   - Run ssh with X11-forwarding connect to sshd on QEMU
     ```
     $ DISPLAY=:0 ssh -X root@192.168.7.2
     ```

   - Run any command and exit
     ```
     # ls
     # exit
     ```

### Run ptest

On QEMU machine.

1. Reset the operation check settings
   ```
   # mv /etc/ssh/sshd_config.orig /etc/ssh/sshd_config
   # rm /etc/default/ssh
   # reboot
   ```

2. Run ptest
   ```
   # ptest-runner -t 7200 openssh | tee openssh.ptest.log
   ```

3. Check ptest log
   ```
   # grep -c '^PASS' ./openssh.ptest.log
   # grep -c '^SKIP' ./openssh.ptest.log
   # grep -c '^FAIL' ./openssh.ptest.log
   ```

## Test result

### Build package and cve-check

The build succeeds and CVE-2025-32728 is `Patched'.

```
deby@2d2b998a6255:~/build$ bitbake openssh
Parsing recipes: 100% |#################################################################################################| Time: 0:00:07
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "openssh-add-CVE-2025-32728-patch:1f92e2635fa258118ec42dc6dc3493bc1d464372"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 431 Found 0 Missed 431 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: openssh-7.9p1-r0 do_cve_check: Found unpatched CVE (CVE-2016-20012 CVE-2020-14145 CVE-2020-15778 CVE-2021-36368), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2015 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```
```
deby@2d2b998a6255:~/build$ grep -A 1 'CVE: CVE-2025-32728' tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
CVE: CVE-2025-32728
CVE STATUS: Patched
```
Before this PR it was as follows:
```
deby@acfaf3cfbe35:~/build$ grep -A 1 'CVE: CVE-2025-32728' tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
CVE: CVE-2025-32728
CVE STATUS: Unpatched
```

### Operation check of CVE-2025-32728 fix

#### Test result of Agent Forwarding

The `agent forwarding disabled` log was output by `DisableForwarding` setting.

Server side log:
```
# rm /root/sshd.log
# /etc/init.d/sshd start
Starting OpenBSD Secure Shell server: sshd
# grep -i forward /root/sshd.log 
debug1: active: key options: agent-forwarding port-forwarding pty user-rc x11-forwarding
debug1: session_auth_agent_req: agent forwarding disabled
```
Client side log:
```
deby@2d2b998a6255:~$ ssh -A root@192.168.7.2
Last login: Thu Jun 12 12:07:34 2025 from 192.168.7.1

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Environment:
  USER=root
  LOGNAME=root
  HOME=/root
  PATH=/usr/bin:/bin:/usr/sbin:/sbin
  MAIL=/var/mail/root
  SHELL=/bin/sh
  TERM=xterm
  SSH_CLIENT=192.168.7.1 57742 22
  SSH_CONNECTION=192.168.7.1 57742 192.168.7.2 22
  SSH_TTY=/dev/pts/1
# ls
sshd.log
# exit
Connection to 192.168.7.2 closed.
```

Before this PR, the logs were not being outputed:
```
# grep -i forward /root/sshd.log
debug1: active: key options: agent-forwarding port-forwarding pty user-rc x11-forwarding
```

#### Test result of X11 Forwarding

The `X11 forwarding disabled in server configuration file.` log was output by `DisableForwarding` setting.

Server side log:
```
# rm /root/sshd.log
# /etc/init.d/sshd start
Starting OpenBSD Secure Shell server: sshd
# grep -i forward /root/sshd.log 
debug1: active: key options: agent-forwarding port-forwarding pty user-rc x11-forwarding
debug1: X11 forwarding disabled in server configuration file.
```

Client side log:
```
deby@2d2b998a6255:~$ DISPLAY=:0 ssh -X root@192.168.7.2
Warning: No xauth data; using fake authentication data for X11 forwarding.
X11 forwarding request failed on channel 0
Last login: Thu Jun 12 12:09:54 2025 from 192.168.7.1

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Environment:
  USER=root
  LOGNAME=root
  HOME=/root
  PATH=/usr/bin:/bin:/usr/sbin:/sbin
  MAIL=/var/mail/root
  SHELL=/bin/sh
  TERM=xterm
  SSH_CLIENT=192.168.7.1 51110 22
  SSH_CONNECTION=192.168.7.1 51110 192.168.7.2 22
  SSH_TTY=/dev/pts/1
# ls
sshd.log
# exit
Connection to 192.168.7.2 closed.
```

Before this PR, the logs were not being outputed:
```
# grep -i forward /root/sshd.log
debug1: active: key options: agent-forwarding port-forwarding pty user-rc x11-forwarding
```

### Run ptest 

The ptest results were the same before and after this PR.

```
# ptest-runner -t 7200 openssh | tee openssh.ptest.log
START: ptest-runner
2025-06-12T12:29
BEGIN: /usr/lib/openssh/ptest
...<snip>...
DURATION: 2633
END: /usr/lib/openssh/ptest
2025-06-12T13:13
STOP: ptest-runner
```
```
# grep -c '^PASS' ./openssh.ptest.log
66
# grep -c '^SKIP' ./openssh.ptest.log
7
# grep -c '^FAIL' ./openssh.ptest.log
0
# grep '^SKIP' ./openssh.ptest.log
SKIP:  (not supported on this platform)
SKIP:  for no openpty(3)
SKIP:  for no openpty(3)
SKIP:  for no openpty(3)
SKIP:  for no openpty(3)
SKIP:  (no suitable ProxyCommand found)
SKIP: agent-ptrace
```

Before this PR:
```
# grep -c '^PASS' ./openssh.ptest.log 
66
# grep -c '^SKIP' ./openssh.ptest.log 
7
# grep -c '^FAIL' ./openssh.ptest.log 
0
# grep '^SKIP' ./openssh.ptest.log 
SKIP:  (not supported on this platform)
SKIP:  for no openpty(3)
SKIP:  for no openpty(3)
SKIP:  for no openpty(3)
SKIP:  for no openpty(3)
SKIP:  (no suitable ProxyCommand found)
SKIP: agent-ptrace
```