### PR TITLE
python3: Add CVE-2017-17522 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/python/python3_debian.bb
+++ b/recipes-debian/python/python3_debian.bb
@@ -312,3 +312,6 @@ RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk tk-li
 RDEPENDS_${PN}-dev = ""
 
 BBCLASSEXTEND = "native nativesdk"
+
+# CVE-2017-17522: The exploitation is impossible.
+CVE_CHECK_WHITELIST = "CVE-2017-17522"


### PR DESCRIPTION
# Purpose of pull request
Add CVE-2017-17522 to CVE_CHECK_WHITELIST because its exploitation is impossible.

# Test
## How to test
Add the following to local.conf.
```
MACHINE = "qemuarm64"
DISTRO = "emlinux-k510"
INHERIT += " cve-check debian-cve-check kernel-cve-check"
```

Run cve-check command.
```
bitbake python3 python3-native -c cve_check
```
Then, compare the log (${WORKDIR}/temp/cve.log) between before and after this update.

## Test result

**Before this update:**
```
$ grep -A1 CVE-2017-17522 python3.log 
CVE: CVE-2017-17522
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2017-17522

$ grep -A1 CVE-2017-17522 python3-native.log 
CVE: CVE-2017-17522
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2017-17522

```

**After this update:**
```
$ grep -A1 CVE-2017-17522 python3.log 
CVE: CVE-2017-17522
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2017-17522

$ grep -A1 CVE-2017-17522 python3-native.log 
CVE: CVE-2017-17522
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2017-17522
```


