### PR TITLE
Fix parsing error caused by "escaped colon" on CPE information of NVD data

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -197,6 +197,7 @@ def check_cves(d, patched_cves):
     """
     Connect to the NVD database and find unpatched cves.
     """
+    import re
     from distutils.version import LooseVersion
 
     cves_unpatched = []
@@ -223,8 +224,8 @@ def check_cves(d, patched_cves):
 
     # For each of the known product names (e.g. curl has CPEs using curl and libcurl)...
     for product in products:
-        if ":" in product:
-            vendor, product = product.split(":", 1)
+        if re.search(r'(?<!\\):', product):
+            vendor, product = re.split(r'(?<!\\):', product, 1)
         else:
             vendor = "%"
 

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -239,6 +239,7 @@ def initialize_db(conn):
         c.close()
 
 def parse_node_and_insert(conn, node, cveId):
+    import re
 
     def cpe_generator():
         for cpe in node.get('cpeMatch', ()):
@@ -247,7 +248,7 @@ def parse_node_and_insert(conn, node, cveId):
             cpe23 = cpe.get('criteria')
             if not cpe23:
                 return
-            cpe23 = cpe23.split(':')
+            cpe23 = re.split(r'(?<!\\):', cpe23)
             if len(cpe23) < 6:
                 return
             vendor = cpe23[3]


### PR DESCRIPTION
# Purpose of pull request

 The CPE information in the NVD data is separated by ":" (colon), but VENDOR and PRODUCT fields strings may contain "\\:" (escaped colon).

In that case, it cannot be parsed correctly, so following commits to fix:

- bfdff546 cve-update-nvd2-native: Fix CPE parse of NVD data
  Saving NVD data to SQLite3 database in cve-update-nvd2-native.bb recipe, correct to exclude 'escaped colon' when split strings by colon.

- 8d250ec4 cve-check: Fix CVE_PRODUCT string parse
  Searching database from CVE_PRODUCT variable in cve-check.bbclass, correct to exclude 'escaped colon' when split strings by colon.

# Test
## How to test

1. Startup the Docker environment.
   ```
   $ cd meta-debian/docker
   $ make start
   ```

2. Setup build environment
   ```
   deby@<container-id>:~$ export TEMPLATECONF=meta-debian/conf
   deby@<container-id>:~$ source ./poky/oe-init-build-env
   ```

3. Setting local.conf

   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   DL_DIR = "${TOPDIR}/downloads"
   INHERIT += " cve-check"
   ```

4. Create database

   ```
   rm -fr ./downloads/CVE_CHECK/
   bitbake cve-update-nvd2-native
   ls -l ./downloads/CVE_CHECK/nvdcve_2-2.db
   ```

5. Check data in database

   Install sqlite3 package.
   ```
   sudo apt install sqlite3
   ```

   Check data in database with sqlite3 command.
   Choose three CVEs for check test.
   ```
   sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2007-4829';"
   sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2020-36659';"
   sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2025-53909';"
   ```

6. Check that CVEs can be detected by specifying CVE_PRODUCT (Only after PR)

   Although the chose CVEs do not target bash, set CVE_PRODUCT to bash package for testing purposes.
   Add following line into conf/local.conf.
   ```
   CVE_PRODUCT_pn-bash = "${BPN}"
   CVE_PRODUCT_pn-bash += "archive\:\:tar_project:archive\:\:tar"
   CVE_PRODUCT_pn-bash += "lemonldap-ng:apache\:\:session\:\:browsable"
   CVE_PRODUCT_pn-bash += "mailcow:mailcow\:_dockerized"
   ```

   Run cve-check for bash.
   ```
   bitbake bash -c cve_check
   ```

   Check the cve-check result.
   ```
   bitbake bash -c cve_check -e | grep '^CVE_PRODUCT'
   grep -C 3 -e 'CVE: CVE-2007-4829' -e 'CVE: CVE-2020-36659' -e 'CVE: CVE-2025-53909' /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
   ```

## Test result
### 4. Create database
```
deby@8f2b30e5baf3:~/build$ bitbake cve-update-nvd2-native
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-CPE-parse-to-deb10.13-2:8d250ec4a38f4cbe61d4471784342b96920a556b"
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 1 Found 0 Missed 1 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 4 tasks of which 0 didn't need to be rerun and all succeeded.
deby@8f2b30e5baf3:~/build$ ls -l ./downloads/CVE_CHECK/nvdcve_2-2.db
-rw-r--r-- 1 deby deby 357027840 Feb 20 08:58 ./downloads/CVE_CHECK/nvdcve_2-2.db
```

### 5. Check data in database
```
deby@8f2b30e5baf3:~/build$ sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2007-4829';"
ID             VENDOR                  PRODUCT         VERSION_START  OPERATOR_START  VERSION_END  OPERATOR_END
-------------  ----------------------  --------------  -------------  --------------  -----------  ------------
CVE-2007-4829  archive\:\:tar_project  archive\:\:tar                                 1.36         <=          
CVE-2007-4829  canonical               ubuntu_linux    6.06           =                                        
CVE-2007-4829  canonical               ubuntu_linux    7.10           =                                        
CVE-2007-4829  canonical               ubuntu_linux    8.04           =                                        
CVE-2007-4829  canonical               ubuntu_linux    8.10           =                                        
deby@8f2b30e5baf3:~/build$ sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2020-36659';"
ID              VENDOR        PRODUCT                         VERSION_START  OPERATOR_START  VERSION_END  OPERATOR_END
--------------  ------------  ------------------------------  -------------  --------------  -----------  ------------
CVE-2020-36659  lemonldap-ng  apache\:\:session\:\:browsable                                 1.3.6        <           
CVE-2020-36659  debian        debian_linux                    10.0           =                                        
deby@8f2b30e5baf3:~/build$ sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2025-53909';"
ID              VENDOR      PRODUCT               VERSION_START  OPERATOR_START  VERSION_END  OPERATOR_END
--------------  ----------  --------------------  -------------  --------------  -----------  ------------
CVE-2025-53909  mailcow     mailcow\:_dockerized                                 2025-07      <           
```

### 6. Check that CVEs can be detected by specifying CVE_PRODUCT (Only after PR)
```
deby@8f2b30e5baf3:~/build$ bitbake bash -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:03
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-CPE-parse-to-deb10.13-2:8d250ec4a38f4cbe61d4471784342b96920a556b"
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276 CVE-2022-31138 CVE-2022-31245 CVE-2022-39258 CVE-2023-26490 CVE-2023-34108 CVE-2023-49077 CVE-2024-23824 CVE-2024-24760 CVE-2024-30270 CVE-2024-31204 CVE-2024-41958 CVE-2024-41959 CVE-2024-41960 CVE-2025-25198 CVE-2025-53909), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
Summary: There was 1 WARNING message shown.
deby@8f2b30e5baf3:~/build$ bitbake bash -c cve_check -e | grep '^CVE_PRODUCT'
CVE_PRODUCT="bash archive\:\:tar_project:archive\:\:tar lemonldap-ng:apache\:\:session\:\:browsable mailcow:mailcow\:_dockerized"
CVE_PRODUCT_pn-bash="bash archive\:\:tar_project:archive\:\:tar lemonldap-ng:apache\:\:session\:\:browsable mailcow:mailcow\:_dockerized"
deby@8f2b30e5baf3:~/build$ grep -C 3 -e 'CVE: CVE-2007-4829' -e 'CVE: CVE-2020-36659' -e 'CVE: CVE-2025-53909' /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
PACKAGE NAME: bash
PACKAGE VERSION: 5.0
CVE: CVE-2007-4829
CVE STATUS: Patched
CVE SUMMARY: Directory traversal vulnerability in the Archive::Tar Perl module 1.36 and earlier allows user-assisted remote attackers to overwrite arbitrary files via a TAR archive that contains a file whose name is an absolute path or has ".." sequences.
CVSS v2 BASE SCORE: 6.8
--
PACKAGE NAME: bash
PACKAGE VERSION: 5.0
CVE: CVE-2020-36659
CVE STATUS: Patched
CVE SUMMARY: In Apache::Session::Browseable before 1.3.6, validity of the X.509 certificate is not checked by default when connecting to remote LDAP backends, because the default configuration of the Net::LDAPS module for Perl is used. NOTE: this can, for example, be fixed in conjunction with the CVE-2020-16093 fix.
CVSS v2 BASE SCORE: 0.0
--
PACKAGE NAME: bash
PACKAGE VERSION: 5.0
CVE: CVE-2025-53909
CVE STATUS: Unpatched
CVE SUMMARY: mailcow: dockerized is an open source groupware/email suite based on docker. A Server-Side Template Injection (SSTI) vulnerability exists in versions prior to 2025-07 in the notification template system used by mailcow for sending quota and quarantine alerts. The template rendering engine allows template expressions that may be abused to execute code in certain contexts. The issue requires admin-level access to mailcow UI to configure templates, which are automatically rendered during normal system operation. Version 2025-07 contains a patch for the issue.
CVSS v2 BASE SCORE: 0.0
```

### For information: 5. Check data in database with before PR
```
deby@f206d4c28ae5:~/build$ ls -l ./downloads/CVE_CHECK/nvdcve_2-2.db
-rw-r--r-- 1 deby deby 357019648 Feb 20 06:08 ./downloads/CVE_CHECK/nvdcve_2-2.db
deby@f206d4c28ae5:~/build$ 
deby@f206d4c28ae5:~/build$ sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2007-4829';"
ID             VENDOR      PRODUCT     VERSION_START         OPERATOR_START  VERSION_END  OPERATOR_END
-------------  ----------  ----------  --------------------  --------------  -----------  ------------
CVE-2007-4829  archive\    \           tar_project_archive\  =                                        
CVE-2007-4829  canonical   ubuntu_lin  6.06                  =                                        
CVE-2007-4829  canonical   ubuntu_lin  7.10                  =                                        
CVE-2007-4829  canonical   ubuntu_lin  8.04                  =                                        
CVE-2007-4829  canonical   ubuntu_lin  8.10                  =                                        
deby@f206d4c28ae5:~/build$ sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2020-36659';"
ID              VENDOR        PRODUCT     VERSION_START  OPERATOR_START  VERSION_END  OPERATOR_END
--------------  ------------  ----------  -------------  --------------  -----------  ------------
CVE-2020-36659  lemonldap-ng  apache\     \_session\     =                                        
CVE-2020-36659  debian        debian_lin  10.0           =                                        
deby@f206d4c28ae5:~/build$ sqlite3 ./downloads/CVE_CHECK/nvdcve_2-2.db -column -header "SELECT * FROM PRODUCTS WHERE ID = 'CVE-2025-53909';"
ID              VENDOR      PRODUCT     VERSION_START  OPERATOR_START  VERSION_END  OPERATOR_END
--------------  ----------  ----------  -------------  --------------  -----------  ------------
CVE-2025-53909  mailcow     mailcow\    _dockerized    =                                        
```