### PR TITLE
openssh: Add CVE-2025-32728 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/openssh/openssh_debian.bb
+++ b/recipes-debian/openssh/openssh_debian.bb
@@ -167,3 +167,8 @@ BBCLASSEXTEND += "nativesdk"
 # does not intent to address it in OpenSSH
 # https://security-tracker.debian.org/tracker/CVE-2023-51767
 CVE_CHECK_WHITELIST += "CVE-2023-51767"
+
+# CVE-2025-32728 has been fixed in fix-disable-forwarding.patch of openssh
+# 7.9p1-10+deb10u6 version, but it's not marked as fixed in dst.json information.
+# https://deb.freexian.com/extended-lts/tracker/CVE-2025-32728
+CVE_CHECK_WHITELIST += "CVE-2025-32728"


### PR DESCRIPTION
# Purpose of pull request

Add CVE-2025-32728 to CVE_CHECK_WHITELIST.

CVE-2025-32728 has been fixed in fix-disable-forwarding.patch of openssh 7.9p1-10+deb10u6 version, but it's not marked as fixed in dst.json information.

# TEST
1. Prepare for testing
2. Build package and cve-check
3. Check source code to applied CVE-2025-32728

## Prepare for testing

Setup Deby build environment
```
$ cd meta-debian/docker
$ make start
```

Setup the build directory
```
$ export TEMPLATECONF=meta-debian/conf
$ source ./poky/oe-init-build-env
```

Add build settings to local.conf
```
build$ echo 'MACHINE = "qemuarm64"'>> conf/local.conf
build$ echo 'DISTRO = "deby"'>> conf/local.conf
build$ echo 'INHERIT += " cve-check debian-cve-check"'>> conf/local.conf
```

## Build package and cve-check

```
build$ bitbake openssh
```

Then, check cve-check result
```
build$ grep -A 1 'CVE: CVE-2025-32728' tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
```

## Check source code to applied CVE-2025-32728

```
build$ cat ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/openssh-7.9p1/debian/patches/fix-disable-forwarding.patch
build$ grep -C 3 -n options.disable_forwarding ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/openssh-7.9p1/session.c
```

## Test result
### Build package and cve-check

The build succeeds and CVE-2025-32728 is `Patched'.
```
deby@aab3dc6970e0:~/build$ bitbake openssh
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "openssh-CVE-2025-32728-to-whitelist:76f76138de852f34eacaa67c3b7aaafc557f1984"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 447 Found 0 Missed 447 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: openssh-7.9p1-r0 do_cve_check: Found unpatched CVE (CVE-2007-2768 CVE-2008-3844 CVE-2016-20012 CVE-2020-14145 CVE-2020-15778 CVE-2021-36368), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2109 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```
```
deby@aab3dc6970e0:~/build$ grep -A 1 'CVE: CVE-2025-32728' tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log 
CVE: CVE-2025-32728
CVE STATUS: Patched
```

### Check source code to applied CVE-2025-32728

Confirmed that fix-disable-forwarding.patch has been applied.
```
deby@aab3dc6970e0:~/build$ cat ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/openssh-7.9p1/debian/patches/fix-disable-forwarding.patch 
From: "djm@openbsd.org" <djm@openbsd.org>
Date: Wed, 9 Apr 2025 07:00:03 +0000
Subject: upstream: Fix logic error in DisableForwarding option. This option

was documented as disabling X11 and agent forwarding but it failed to do so.
Spotted by Tim Rice.

OpenBSD-Commit-ID: fffc89195968f7eedd2fc57f0b1f1ef3193f5ed1

Origin: upstream, https://anongit.mindrot.org/openssh.git/commit/?id=fc86875e6acb36401dfc1dfb6b628a9d1460f367
Bug-Debian: https://bugs.debian.org/1102603
Last-Update: 2025-04-15
---
 session.c | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)

diff --git a/session.c b/session.c
index 19f3863..f2b3f57 100644
--- a/session.c
+++ b/session.c
@@ -2182,7 +2182,8 @@ session_auth_agent_req(struct ssh *ssh, Session *s)
 
 	packet_check_eom();
 	if (!auth_opts->permit_agent_forwarding_flag ||
-	    !options.allow_agent_forwarding) {
+	    !options.allow_agent_forwarding ||
+	    options.disable_forwarding) {
 		debug("%s: agent forwarding disabled", __func__);
 		return 0;
 	}
@@ -2568,7 +2569,7 @@ session_setup_x11fwd(struct ssh *ssh, Session *s)
 		packet_send_debug("X11 forwarding disabled by key options.");
 		return 0;
 	}
-	if (!options.x11_forwarding) {
+	if (!options.x11_forwarding || options.disable_forwarding) {
 		debug("X11 forwarding disabled in server configuration file.");
 		return 0;
 	}
deby@aab3dc6970e0:~/build$ grep -C 3 -n options.disable_forwarding ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/openssh-7.9p1/session.c 
346-	set_fwdpermit_from_authopts(ssh, auth_opts);
347-
348-	if (!auth_opts->permit_port_forwarding_flag ||
349:	    options.disable_forwarding) {
350-		channel_disable_admin(ssh, FORWARD_LOCAL);
351-		channel_disable_admin(ssh, FORWARD_REMOTE);
352-	} else {
--
2183-	packet_check_eom();
2184-	if (!auth_opts->permit_agent_forwarding_flag ||
2185-	    !options.allow_agent_forwarding ||
2186:	    options.disable_forwarding) {
2187-		debug("%s: agent forwarding disabled", __func__);
2188-		return 0;
2189-	}
--
2569-		packet_send_debug("X11 forwarding disabled by key options.");
2570-		return 0;
2571-	}
2572:	if (!options.x11_forwarding || options.disable_forwarding) {
2573-		debug("X11 forwarding disabled in server configuration file.");
2574-		return 0;
2575-	}
```
That is as stated in the changelog.
```
deby@aab3dc6970e0:~/build$ grep -C 3 -n CVE-2025-32728 ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/openssh-7.9p1/debian/changelog 
60-
61-openssh (1:7.9p1-10+deb10u6) buster-security; urgency=medium
62-
63:  * CVE-2025-32728: sshd(8): fix the DisableForwarding directive, which was
64-    failing to disable X11 forwarding and agent forwarding as documented
65-    (closes: #1102603).
66-
```