### PR TITLE
recipes-core/cve-update: Update loop condition in update_db_file()

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -208,6 +208,10 @@ def update_db_file(db_tmp_file, d, database_time):
             for cve in data["vulnerabilities"]:
                update_db(conn, cve)
 
+            if per_page == 0:
+                # no more data
+                break
+
             index += per_page
             if index >= total:
                break


### PR DESCRIPTION
We used to check index value to break loop or not, but this check doesn't work recent API behavior change by NVD API.
Thereby, it goes loop forever.

```
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=96&lastModStartDate=2026-05-22T16%3A24%3A58%2B00%3A00&lastModEndDate=2026-05-23T04%3A13%3A37.418777%2B00%3A00
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 2 entries
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-5072 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-8381 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=98&lastModStartDate=2026-05-22T16%3A24%3A58%2B00%3A00&lastModEndDate=2026-05-23T04%3A13%3A37.418777%2B00%3A00
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 0 entries
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=98&lastModStartDate=2026-05-22T16%3A24%3A58%2B00%3A00&lastModEndDate=2026-05-23T04%3A13%3A37.418777%2B00%3A00
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 0 entries
```

This commit add to check resultsPerPage vaule. If this value is 0, there is no more data. so we can break the loop.

# Test

Add following lines in local.conf. This setting uses CVE_DB_PREDOWNLOAD feature, so you need to be able to download pre-created database.

```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
NVDCVE_API_KEY="<your api key>"
CVE_DB_PREDOWNLOAD="1"
```

Then run following command.

```
bitbake bash -c cve_check -v
```

# Test result

When CVE data count is 0, it successfully break the loop.

```
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-46598 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-9054 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-44409 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=104&lastModStartDate=2026-05-22T16%3A24%3A58%2B00%3A00&lastModEndDate=2026-05-25T01%3A31%3A39.116896%2B00%3A00
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 2 entries
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-5072 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE CVE-2026-8381 has no configurations
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=106&lastModStartDate=2026-05-22T16%3A24%3A58%2B00%3A00&lastModEndDate=2026-05-25T01%3A31%3A39.116896%2B00%3A00
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 0 entries
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Download json file from https://deb.freexian.com/extended-lts/tracker/data/json
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 is not vulnerable to CVE-1999-0491
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 is not vulnerable to CVE-1999-1383
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2010-0002
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2012-3410
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2012-6711
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2014-6271
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2014-6277
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2014-6278
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2014-7169
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2014-7186
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2014-7187
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2016-0634
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2016-7543
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2016-9401
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2017-5932
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 is vulnerable to CVE-2019-18276
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2019-9924
NOTE: bash-5.0-r0 do_cve_check: bash-5.0 has been whitelisted for CVE-2022-3715
NOTE: bash-5.0-r0 do_cve_check: Call to 'debian_check_cves_func' function.
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /home/build/work/build/tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/temp/cve.log
NOTE: bash-5.0-r0 do_cve_check: Writing file /home/build/work/build/tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/temp/cve.log with CVE information
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
````

I also checked create database from scratch that succeeded as well.
